### PR TITLE
Encrypt transfer tx message on sign

### DIFF
--- a/src/core/database/entities/TransferTransactionWithToBeEncryptedMessage.ts
+++ b/src/core/database/entities/TransferTransactionWithToBeEncryptedMessage.ts
@@ -1,0 +1,27 @@
+import {
+    Deadline,
+    Message,
+    Mosaic,
+    NetworkType,
+    PublicAccount,
+    TransactionVersion,
+    TransferTransaction,
+    UInt64,
+    UnresolvedAddress,
+} from 'symbol-sdk';
+
+export class TransferTransactionWithToBeEncryptedMessage extends TransferTransaction {
+    constructor(
+        public recipientAcount: PublicAccount,
+        deadline: Deadline,
+        mosaics: Mosaic[],
+        message: Message,
+        networkType: NetworkType,
+        recipientAddress: UnresolvedAddress,
+        maxFee?: UInt64,
+        signature?: string,
+        signer?: PublicAccount,
+    ) {
+        super(networkType, TransactionVersion.TRANSFER, deadline, maxFee, recipientAddress, mosaics, message, signature, signer);
+    }
+}


### PR DESCRIPTION
At the moment the transaction message gets encrypted immediately when the user clicks on the encryption checkbox. The problem here is that when the message is changed afterwards, the changes are totally ignored and the original message is sent. As a solution the message should be encrypted after the user clicks on Confirm in the Sign transaction modal dialog.

The challenge here is that at the time, the Sign transaction modal dialog is shown, the transaction object is already built and the message is readonly. An elegant solution might be to move the message encryption to the SDK where the transaction is signed. But since that is quite time consuming to implement, I made a quick and dirty solution. It is already working but not finished and there are some questions to be resolved (like how to handle imported transactions). If you generally agree with this I would finish it so we have this feature for the release.