### PR TITLE
fix: using AGGREGATE_COMPLETE on aggregate txs when requiredCosignatures is 1

### DIFF
--- a/src/views/forms/FormTransactionBase/FormTransactionBase.ts
+++ b/src/views/forms/FormTransactionBase/FormTransactionBase.ts
@@ -288,8 +288,8 @@ export class FormTransactionBase extends Vue {
 
     protected getTransactionCommandMode(transactions: Transaction[]): TransactionCommandMode {
         if (this.isMultisigMode()) {
-            // If min Approval equal one, we can announce it with AggregateComplete to skip the lock fees.
-            if (this.currentSignerMultisigInfo?.minApproval === 1) {
+            // If `requiredCosignatures` equals to one, we can announce it with AggregateComplete to skip the lock fees.
+            if (this.requiredCosignatures === 1) {
                 return TransactionCommandMode.AGGREGATE;
             }
 


### PR DESCRIPTION
Especially in FormMultisigAccountModificationTransaction and FormPersistentDelegationRequestTransaction forms some cases were uncovered; refactored to use `requiredCosignatures` in the base class and refactored harvesting form to create agg complete tx when possible.