### PR TITLE
fix: multisig account owned mosaic actions visibility issue fixed

### DIFF
--- a/src/components/TableDisplay/TableDisplayTs.ts
+++ b/src/components/TableDisplay/TableDisplayTs.ts
@@ -51,7 +51,6 @@ import ModalMetadataDisplay from '@/views/modals/ModalMetadataDisplay/ModalMetad
 import { NamespaceModel } from '@/core/database/entities/NamespaceModel';
 import { MosaicModel } from '@/core/database/entities/MosaicModel';
 import { NetworkConfigurationModel } from '@/core/database/entities/NetworkConfigurationModel';
-import { AccountModel } from '@/core/database/entities/AccountModel';
 import { Signer } from '@/store/Account';
 // @ts-ignore
 import SignerFilter from '@/components/SignerFilter/SignerFilter.vue';
@@ -75,13 +74,13 @@ import { PageInfo } from '@/store/Transaction';
     computed: {
         ...mapGetters({
             currentHeight: 'network/currentHeight',
-            currentAccount: 'account/currentAccount',
             holdMosaics: 'mosaic/holdMosaics',
             ownedNamespaces: 'namespace/ownedNamespaces',
             currentConfirmedPage: 'namespace/currentConfirmedPage',
             attachedMetadataList: 'metadata/accountMetadataList',
             networkConfiguration: 'network/networkConfiguration',
             signers: 'account/signers',
+            currentSigner: 'account/currentSigner',
             isFetchingNamespaces: 'namespace/isFetchingNamespaces',
             isFetchingMosaics: 'mosaic/isFetchingMosaics',
             isFetchingMetadata: 'metadata/isFetchingMetadata',
@@ -128,11 +127,11 @@ export class TableDisplayTs extends Vue {
      */
     protected targetedMetadataList: MetadataModel[];
 
-    private currentAccount: AccountModel;
-
     private currentHeight: number;
 
     private networkConfiguration: NetworkConfigurationModel;
+
+    private currentSigner: Signer;
 
     /**
      * current signers
@@ -217,7 +216,7 @@ export class TableDisplayTs extends Vue {
         return this.assetType === 'namespace'
             ? this.ownedNamespaces.map(({ namespaceIdHex }) => namespaceIdHex)
             : this.holdMosaics
-                  .filter(({ ownerRawPlain }) => ownerRawPlain === this.currentAccount.address)
+                  .filter(({ ownerRawPlain }) => ownerRawPlain === this.currentSigner.address.plain())
                   .map(({ mosaicIdHex }) => mosaicIdHex);
     }
 


### PR DESCRIPTION
fixes https://github.com/symbol/desktop-wallet/issues/1679

Was filtering out only the currentAccount(changed to currentSigner now) for the actions on the mosaic list therefore missing the multisig accounts, looks like the issue was always there but became more visible with the 'sticky' signer selection fix.