### PR TITLE
fix: transfer and metadata tx form multi-level multi-sig agg complete fix

### DIFF
--- a/src/views/forms/FormMetadataCreation/FormMetadataCreationTs.ts
+++ b/src/views/forms/FormMetadataCreation/FormMetadataCreationTs.ts
@@ -233,7 +233,7 @@ export class FormMetadataCreationTs extends FormTransactionBase {
         if (!this.selectedSigner.multisig && this.formItems.signerAddress !== this.getTargetAddress().plain()) {
             return 1;
         }
-        return super.requiredCosignatures;
+        return this.selectedSigner.multisig ? this.multisigRequiredCosignatures : this.selectedSigner.requiredCosignatures;
     }
 
     /**

--- a/src/views/forms/FormMetadataCreation/FormMetadataCreationTs.ts
+++ b/src/views/forms/FormMetadataCreation/FormMetadataCreationTs.ts
@@ -233,7 +233,7 @@ export class FormMetadataCreationTs extends FormTransactionBase {
         if (!this.selectedSigner.multisig && this.formItems.signerAddress !== this.getTargetAddress().plain()) {
             return 1;
         }
-        return this.currentSignerMultisigInfo ? this.currentSignerMultisigInfo.minApproval : this.selectedSigner.requiredCosignatures;
+        return super.requiredCosignatures;
     }
 
     /**

--- a/src/views/forms/FormTransactionBase/FormTransactionBase.ts
+++ b/src/views/forms/FormTransactionBase/FormTransactionBase.ts
@@ -45,7 +45,6 @@ import { NetworkConfigurationModel } from '@/core/database/entities/NetworkConfi
             transactionFees: 'network/transactionFees',
             isOfflineMode: 'network/isOfflineMode',
             multisigAccountGraphInfo: 'account/multisigAccountGraphInfo',
-            multisigAccountGraph: 'account/multisigAccountGraph',
         }),
     },
 })
@@ -141,8 +140,6 @@ export class FormTransactionBase extends Vue {
     protected isOfflineMode: boolean;
 
     protected multisigAccountGraphInfo: MultisigAccountInfo[];
-
-    protected multisigAccountGraph: MultisigAccountInfo[][];
 
     /**
      * Type the ValidationObserver refs

--- a/src/views/forms/FormTransactionBase/FormTransactionBase.ts
+++ b/src/views/forms/FormTransactionBase/FormTransactionBase.ts
@@ -45,6 +45,7 @@ import { NetworkConfigurationModel } from '@/core/database/entities/NetworkConfi
             transactionFees: 'network/transactionFees',
             isOfflineMode: 'network/isOfflineMode',
             multisigAccountGraphInfo: 'account/multisigAccountGraphInfo',
+            multisigAccountGraph: 'account/multisigAccountGraph',
         }),
     },
 })
@@ -139,7 +140,9 @@ export class FormTransactionBase extends Vue {
 
     protected isOfflineMode: boolean;
 
-    private multisigAccountGraphInfo: MultisigAccountInfo[];
+    protected multisigAccountGraphInfo: MultisigAccountInfo[];
+
+    protected multisigAccountGraph: MultisigAccountInfo[][];
 
     /**
      * Type the ValidationObserver refs
@@ -308,21 +311,23 @@ export class FormTransactionBase extends Vue {
         return this.isMultisigMode() ? this.multisigRequiredCosignatures : this.selectedSigner.requiredCosignatures;
     }
 
-    private get multisigRequiredCosignatures(): number {
-        // travel every level from current account to the current signer in the tree and return the max minApproval found
+    /**
+     * travel every level from current account to the current signer in the tree and return the max minApproval found
+     */
+    protected get multisigRequiredCosignatures(): number {
         if (this.multisigAccountGraphInfo?.length < 2) {
             // it is not a multilevel multisig then return current minApproval
-            return this.currentSignerMultisigInfo.minApproval;
+            return this.currentSignerMultisigInfo?.minApproval || 0;
         }
-        let maxOfminApprovals = 1;
+        let maxOfMinApprovals = 1;
         for (let inx = 0; inx < this.multisigAccountGraphInfo.length; inx++) {
             const currentLevel: MultisigAccountInfo = this.multisigAccountGraphInfo[inx];
-            maxOfminApprovals = Math.max(currentLevel.minApproval, maxOfminApprovals);
+            maxOfMinApprovals = Math.max(currentLevel.minApproval, maxOfMinApprovals);
             if (currentLevel.accountAddress.plain() === this.selectedSigner.address.plain()) {
                 break;
             }
         }
-        return maxOfminApprovals;
+        return maxOfMinApprovals;
     }
 
     /**


### PR DESCRIPTION
Calculates correct required cosignatures needed and creates `aggregate complete` tx if there is no multi-sig signer in the tree(_between the levels from selected signer to the current account_) that has `minApproval` greater than 1.

Known issue with the current implementation => https://github.com/symbol/desktop-wallet/issues/1687
Will use a tree-like data structure to implement it.