### PR TITLE
fix: multisig account graph info stored value fix

### DIFF
--- a/src/store/Account.ts
+++ b/src/store/Account.ts
@@ -527,8 +527,9 @@ export default {
                     map((g) => {
                         // sorted array to be represented in multisig tree
                         commit('multisigAccountGraph', g.multisigEntries);
-                        commit('multisigAccountGraphInfo', MultisigService.getMultisigGraphArraySorted(g.multisigEntries));
-                        return MultisigService.getMultisigInfoFromMultisigGraphInfo(g);
+                        const infoFromGraph = MultisigService.getMultisigInfoFromMultisigGraphInfo(g);
+                        commit('multisigAccountGraphInfo', infoFromGraph);
+                        return infoFromGraph;
                     }),
                     catchError(() => {
                         commit('multisigAccountGraphInfo', []);

--- a/src/views/forms/FormMultisigAccountModificationTransaction/FormMultisigAccountModificationTransactionTs.ts
+++ b/src/views/forms/FormMultisigAccountModificationTransaction/FormMultisigAccountModificationTransactionTs.ts
@@ -460,7 +460,7 @@ export class FormMultisigAccountModificationTransactionTs extends FormTransactio
      */
     private get multisigRequiredCosignaturesForRemoval(): number {
         // travel every level from current account to the current signer in the tree and return the max minRemoval found
-        if (this.multisigAccountGraphInfo?.length < 2) {
+        if (this.multisigAccountGraphInfo?.length <= 2) {
             // it is not a multilevel multisig then return current minRemoval
             return this.currentSignerMultisigInfo?.minRemoval || 0;
         }

--- a/src/views/forms/FormTransactionBase/FormTransactionBase.ts
+++ b/src/views/forms/FormTransactionBase/FormTransactionBase.ts
@@ -312,7 +312,7 @@ export class FormTransactionBase extends Vue {
      * travel every level from current account to the current signer in the tree and return the max minApproval found
      */
     protected get multisigRequiredCosignatures(): number {
-        if (this.multisigAccountGraphInfo?.length < 2) {
+        if (this.multisigAccountGraphInfo?.length <= 2) {
             // it is not a multilevel multisig then return current minApproval
             return this.currentSignerMultisigInfo?.minApproval || 0;
         }


### PR DESCRIPTION
`multisigAccountGraphInfo` store value was set to an array of arrays at one line and flat array at another, I think this PR will fix it to use the same value.

![image](https://user-images.githubusercontent.com/6256269/131808534-423ebe76-7e21-48d0-a460-01c0560fe4a1.png)
