### PR TITLE
Ledger harvesting

### DIFF
--- a/src/views/forms/FormPersistentDelegationRequestTransaction/FormPersistentDelegationRequestTransactionTs.ts
+++ b/src/views/forms/FormPersistentDelegationRequestTransaction/FormPersistentDelegationRequestTransactionTs.ts
@@ -170,8 +170,8 @@ export class FormPersistentDelegationRequestTransactionTs extends FormTransactio
 
     private tempTransactionSigner: TransactionSigner;
     private tempAccount: Account;
-    public vrfPrivateKeyTemp: string;
-    public remotePrivateKeyTemp: string;
+    public vrfPrivateKeyTemp: string = '';
+    public remotePrivateKeyTemp: string = '';
 
     /**
      * Panel tab management getters/setters
@@ -238,7 +238,7 @@ export class FormPersistentDelegationRequestTransactionTs extends FormTransactio
      * @var {string}
      */
     private type: string;
-    private password: string;
+    private password: string = '';
     private linkIcon: string = officialIcons.publicChain;
     private linking = false;
     private showModalImportKey: boolean = false;
@@ -710,13 +710,13 @@ export class FormPersistentDelegationRequestTransactionTs extends FormTransactio
     public saveVrfKey(accountAddress: string, encVrfPrivateKey: string) {
         this.$store.dispatch('harvesting/UPDATE_VRF_ACCOUNT_PRIVATE_KEY', { accountAddress, encVrfPrivateKey });
     }
-    public saveVrfKeyInfo(accountAddress: string, newEncVrfPrivateKey: string, newVrfPublicKey) {
+    public saveVrfKeyInfo(accountAddress: string, newEncVrfPrivateKey: string, newVrfPublicKey: string) {
         this.$store.dispatch('harvesting/UPDATE_NEW_VRF_KEY_INFO', { accountAddress, newEncVrfPrivateKey, newVrfPublicKey });
     }
     public saveRemoteKey(accountAddress: string, encRemotePrivateKey: string) {
         this.$store.dispatch('harvesting/UPDATE_REMOTE_ACCOUNT_PRIVATE_KEY', { accountAddress, encRemotePrivateKey });
     }
-    public saveRemoteKeyInfo(accountAddress: string, newEncRemotePrivateKey: string, newRemotePublicKey) {
+    public saveRemoteKeyInfo(accountAddress: string, newEncRemotePrivateKey: string, newRemotePublicKey: string) {
         this.$store.dispatch('harvesting/UPDATE_NEW_REMOTE_KEY_INFO', {
             accountAddress,
             newEncRemotePrivateKey,

--- a/src/views/modals/ModalTransactionConfirmation/ModalTransactionConfirmationTs.ts
+++ b/src/views/modals/ModalTransactionConfirmation/ModalTransactionConfirmationTs.ts
@@ -578,26 +578,8 @@ export class ModalTransactionConfirmationTs extends Vue {
     private async ledgerAccDelHarvestKeyOnStop(values) {
         const accountAddress = this.command.currentSignerHarvestingModel.accountAddress;
 
-        // store new vrf Key info in local
-        if (this.command?.vrfPrivateKeyTemp) {
-            this.saveVrfKeyInfo(
-                accountAddress,
-                Crypto.encrypt(this.command.newVrfKeyAccount.privateKey, this.command.password),
-                this.command.newVrfKeyAccount.publicKey,
-            );
-        }
-
-        // store new remote Key info in local
-        if (this.command?.remotePrivateKeyTemp) {
-            this.saveRemoteKeyInfo(
-                accountAddress,
-                Crypto.encrypt(this.command.newRemoteAccount.privateKey, this.command.password),
-                this.command.newRemoteAccount.publicKey,
-            );
-        }
-
-        // // pre-store selected harvesting node in local
-        this.saveHarvestingNode(accountAddress, this.command.formItems.nodeModel);
+        // pre store vrf and remote Key in local
+        this.preStoreHarvestingKeyInfo(accountAddress);
 
         const { ledgerService, currentPath, isOptinLedgerWallet, ledgerAccount } = values;
         const keyUnLinkAggregateCompleteTransaction = this.stagedTransactions[0];
@@ -762,26 +744,7 @@ export class ModalTransactionConfirmationTs extends Vue {
     private async ledgerAccMultisigDelHarvestKeyOnStop(values) {
         const accountAddress = this.command.currentSignerHarvestingModel.accountAddress;
 
-        // store new vrf Key info in local
-        if (this.command.vrfPrivateKeyTemp) {
-            this.saveVrfKeyInfo(
-                accountAddress,
-                Crypto.encrypt(this.command.newVrfKeyAccount.privateKey, this.command.password),
-                this.command.newVrfKeyAccount.publicKey,
-            );
-        }
-
-        // store new remote Key info in local
-        if (this.command.remotePrivateKeyTemp) {
-            this.saveRemoteKeyInfo(
-                accountAddress,
-                Crypto.encrypt(this.command.newRemoteAccount.privateKey, this.command.password),
-                this.command.newRemoteAccount.publicKey,
-            );
-        }
-
-        // // pre-store selected harvesting node in local
-        this.saveHarvestingNode(accountAddress, this.command.formItems.nodeModel);
+        this.preStoreHarvestingKeyInfo(accountAddress);
 
         const { ledgerService, currentPath, ledgerAccount } = values;
 
@@ -957,5 +920,32 @@ export class ModalTransactionConfirmationTs extends Vue {
             accountAddress,
             newSelectedHarvestingNode: harvestingNode,
         });
+    }
+
+    /**
+     * Pre store harvesting key info in local;
+     * @param accountAddress
+     */
+    private preStoreHarvestingKeyInfo(accountAddress: string): void {
+        // store new vrf Key info in local
+        if (this.command?.vrfPrivateKeyTemp) {
+            this.saveVrfKeyInfo(
+                accountAddress,
+                Crypto.encrypt(this.command.newVrfKeyAccount.privateKey, this.command.password),
+                this.command.newVrfKeyAccount.publicKey,
+            );
+        }
+
+        // store new remote Key info in local
+        if (this.command?.remotePrivateKeyTemp) {
+            this.saveRemoteKeyInfo(
+                accountAddress,
+                Crypto.encrypt(this.command.newRemoteAccount.privateKey, this.command.password),
+                this.command.newRemoteAccount.publicKey,
+            );
+        }
+
+        // // pre-store selected harvesting node in local
+        this.saveHarvestingNode(accountAddress, this.command.formItems.nodeModel);
     }
 }

--- a/src/views/modals/ModalTransactionConfirmation/ModalTransactionConfirmationTs.ts
+++ b/src/views/modals/ModalTransactionConfirmation/ModalTransactionConfirmationTs.ts
@@ -47,6 +47,7 @@ import { AccountService } from '@/services/AccountService';
 import { LedgerService } from '@/services/LedgerService';
 
 // internal dependencies
+import { NodeModel } from '@/core/database/entities/NodeModel';
 import { AccountModel, AccountType } from '@/core/database/entities/AccountModel';
 import { LedgerHarvestingMode } from '@/store/Harvesting';
 import { AccountTransactionSigner, TransactionAnnouncerService, TransactionSigner } from '@/services/TransactionAnnouncerService';
@@ -575,6 +576,29 @@ export class ModalTransactionConfirmationTs extends Vue {
     }
 
     private async ledgerAccDelHarvestKeyOnStop(values) {
+        const accountAddress = this.command.currentSignerHarvestingModel.accountAddress;
+
+        // store new vrf Key info in local
+        if (this.command?.vrfPrivateKeyTemp) {
+            this.saveVrfKeyInfo(
+                accountAddress,
+                Crypto.encrypt(this.command.newVrfKeyAccount.privateKey, this.command.password),
+                this.command.newVrfKeyAccount.publicKey,
+            );
+        }
+
+        // store new remote Key info in local
+        if (this.command?.remotePrivateKeyTemp) {
+            this.saveRemoteKeyInfo(
+                accountAddress,
+                Crypto.encrypt(this.command.newRemoteAccount.privateKey, this.command.password),
+                this.command.newRemoteAccount.publicKey,
+            );
+        }
+
+        // // pre-store selected harvesting node in local
+        this.saveHarvestingNode(accountAddress, this.command.formItems.nodeModel);
+
         const { ledgerService, currentPath, isOptinLedgerWallet, ledgerAccount } = values;
         const keyUnLinkAggregateCompleteTransaction = this.stagedTransactions[0];
         this.$store.dispatch('notification/ADD_SUCCESS', 'verify_device_information');
@@ -590,7 +614,6 @@ export class ModalTransactionConfirmationTs extends Vue {
         const services = new TransactionAnnouncerService(this.$store);
         services.announce(signedKeyUnLinkAggregateCompleteTransaction).subscribe((res) => {
             if (res.success) {
-                const accountAddress = this.command.currentSignerHarvestingModel.accountAddress;
                 // @ts-ignore
                 if (!!res.transaction?.innerTransactions) {
                     // @ts-ignore
@@ -653,11 +676,6 @@ export class ModalTransactionConfirmationTs extends Vue {
                         });
                     }
                 }
-
-                this.$store.dispatch('harvesting/UPDATE_ACCOUNT_SELECTED_HARVESTING_NODE', {
-                    accountAddress,
-                    selectedHarvestingNode: this.command.formItems.nodeModel,
-                });
             }
         });
         this.show = false;
@@ -742,6 +760,29 @@ export class ModalTransactionConfirmationTs extends Vue {
     }
 
     private async ledgerAccMultisigDelHarvestKeyOnStop(values) {
+        const accountAddress = this.command.currentSignerHarvestingModel.accountAddress;
+
+        // store new vrf Key info in local
+        if (this.command.vrfPrivateKeyTemp) {
+            this.saveVrfKeyInfo(
+                accountAddress,
+                Crypto.encrypt(this.command.newVrfKeyAccount.privateKey, this.command.password),
+                this.command.newVrfKeyAccount.publicKey,
+            );
+        }
+
+        // store new remote Key info in local
+        if (this.command.remotePrivateKeyTemp) {
+            this.saveRemoteKeyInfo(
+                accountAddress,
+                Crypto.encrypt(this.command.newRemoteAccount.privateKey, this.command.password),
+                this.command.newRemoteAccount.publicKey,
+            );
+        }
+
+        // // pre-store selected harvesting node in local
+        this.saveHarvestingNode(accountAddress, this.command.formItems.nodeModel);
+
         const { ledgerService, currentPath, ledgerAccount } = values;
 
         const lockFundsKeyUnLinkAggregateBondedTransaction = this.stagedTransactions[0];
@@ -769,7 +810,6 @@ export class ModalTransactionConfirmationTs extends Vue {
         const service = new TransactionAnnouncerService(this.$store);
         this.command.announceHashAndAggregateBonded(service, signedKeyLinkTransactions).subscribe((res) => {
             if (res.success) {
-                const accountAddress = this.command.currentSignerHarvestingModel.accountAddress;
                 if (!!res.transaction?.innerTransactions) {
                     // @ts-ignore
                     res.transaction?.innerTransactions.forEach((val) => {
@@ -803,10 +843,6 @@ export class ModalTransactionConfirmationTs extends Vue {
                         isPersistentDelReqSent: false,
                     });
                 }
-                this.$store.dispatch('harvesting/UPDATE_ACCOUNT_SELECTED_HARVESTING_NODE', {
-                    accountAddress,
-                    selectedHarvestingNode: this.command.formItems.nodeModel,
-                });
             }
         });
         this.show = false;
@@ -895,5 +931,31 @@ export class ModalTransactionConfirmationTs extends Vue {
     public onConfirmationSuccess() {
         this.$store.dispatch('notification/ADD_SUCCESS', 'success_transactions_signed');
         this.$emit('success');
+    }
+
+    private saveVrfKeyInfo(accountAddress: string, newEncVrfPrivateKey: string, newVrfPublicKey: string) {
+        this.$store.dispatch('harvesting/UPDATE_NEW_VRF_KEY_INFO', { accountAddress, newEncVrfPrivateKey, newVrfPublicKey });
+    }
+
+    private saveRemoteKeyInfo(accountAddress: string, newEncRemotePrivateKey: string, newRemotePublicKey: string) {
+        this.$store.dispatch('harvesting/UPDATE_NEW_REMOTE_KEY_INFO', {
+            accountAddress,
+            newEncRemotePrivateKey,
+            newRemotePublicKey,
+        });
+    }
+
+    private saveHarvestingNode(accountAddress: string, harvestingNode: NodeModel) {
+        this.$store.dispatch('harvesting/UPDATE_ACCOUNT_SELECTED_HARVESTING_NODE', {
+            accountAddress,
+            selectedHarvestingNode: harvestingNode,
+        });
+
+        // store announced harvesting node in local storage.
+        // it can be use when connection interrupt or waiting for co-signature.
+        this.$store.dispatch('harvesting/UPDATE_ACCOUNT_NEW_SELECTED_HARVESTING_NODE', {
+            accountAddress,
+            newSelectedHarvestingNode: harvestingNode,
+        });
     }
 }


### PR DESCRIPTION
### Fix
- Store vrf and remote key info before announce.
- unable to unlink a single key, caused by some [reactive properties](https://vuejs.org/v2/guide/reactivity.html#Declaring-Reactive-Properties) undefine, and assign a default value.