### PR TITLE
multi-level msig required cosignatures,  txs issues fixed, signer selector&filter tree view, misc. bugfixes

### DIFF
--- a/__tests__/components/TransactionList/TransactionListFilters/TransactionListFilter.spec.ts
+++ b/__tests__/components/TransactionList/TransactionListFilters/TransactionListFilter.spec.ts
@@ -10,7 +10,7 @@ beforeEach(() => {
     wrapper = getComponent(
         TransactionListFilters,
         { account: AccountStore, transaction: TransactionStore },
-        { currentAccount: null, signers: [] },
+        { currentAccount: null, currentAccountSigner: {}, signers: [] },
         {},
         {},
     );

--- a/src/components/AccountMultisigGraph/AccountMultisigGraphTs.ts
+++ b/src/components/AccountMultisigGraph/AccountMultisigGraphTs.ts
@@ -42,7 +42,7 @@ export class AccountMultisigGraphTs extends Vue {
     public knownAccounts: AccountModel[];
 
     get multisigGraphTree(): any[] {
-        if (this.multisigAccountGraphInfo) {
+        if (this.multisigAccountGraphInfo?.size) {
             return this.getMultisigDisplayGraph(this.multisigAccountGraphInfo);
         }
         return [];

--- a/src/components/AccountRestrictionsList/AccountRestrictionsList.vue
+++ b/src/components/AccountRestrictionsList/AccountRestrictionsList.vue
@@ -3,8 +3,8 @@
         <div class="upper-section-container">
             <div class="table-title-container section-title">
                 <div class="user-operation">
-                    <div v-if="signers.length > 1" style="min-width: 2rem;">
-                        <SignerFilter :signers="signers" @signer-change="onSignerSelectorChange" />
+                    <div v-if="currentAccountSigner.parentSigners" style="min-width: 2rem;">
+                        <SignerFilter :root-signer="currentAccountSigner" @signer-change="onSignerSelectorChange" />
                     </div>
                     <span class="table-filter-item-container" @click="doRefresh">
                         <Icon :class="{ 'animation-rotate': isRefreshing }" type="ios-sync" />

--- a/src/components/AccountRestrictionsList/AccountRestrictionsList.vue
+++ b/src/components/AccountRestrictionsList/AccountRestrictionsList.vue
@@ -4,7 +4,7 @@
             <div class="table-title-container section-title">
                 <div class="user-operation">
                     <div v-if="currentAccountSigner.parentSigners" style="min-width: 2rem;">
-                        <SignerFilter :root-signer="currentAccountSigner" @signer-change="onSignerSelectorChange" />
+                        <SignerListFilter :root-signer="currentAccountSigner" @signer-change="onSignerSelectorChange" />
                     </div>
                     <span class="table-filter-item-container" @click="doRefresh">
                         <Icon :class="{ 'animation-rotate': isRefreshing }" type="ios-sync" />

--- a/src/components/AccountRestrictionsList/AccountRestrictionsListTs.ts
+++ b/src/components/AccountRestrictionsList/AccountRestrictionsListTs.ts
@@ -16,7 +16,7 @@
 // @ts-ignore
 import ButtonAdd from '@/components/ButtonAdd/ButtonAdd';
 // @ts-ignore
-import SignerFilter from '@/components/SignerFilter/SignerFilter.vue';
+import SignerListFilter from '@/components/SignerListFilter/SignerListFilter.vue';
 // @ts-ignore
 import { TableAssetType } from '@/components/TableDisplay/TableAssetType';
 // @ts-ignore
@@ -60,7 +60,7 @@ export type AccountRestrictionTableField = {
         FormExtendNamespaceDurationTransaction,
         FormMosaicSupplyChangeTransaction,
         ModalMetadataDisplay,
-        SignerFilter,
+        SignerListFilter,
         ButtonAdd,
         ModalMetadataUpdate,
     },

--- a/src/components/SignerBaseFilter/SignerBaseFilter.vue
+++ b/src/components/SignerBaseFilter/SignerBaseFilter.vue
@@ -17,39 +17,6 @@
     </div>
 </template>
 <script lang="ts">
-// @ts-ignore
-import { SignerFilterTs } from './SignerFilterTs';
-export default class SignerFilter extends SignerFilterTs {}
+import { SignerBaseFilterTs } from './SignerBaseFilterTs';
+export default class SignerBaseFilter extends SignerBaseFilterTs {}
 </script>
-<style lang="less" scoped>
-@import '../../views/resources/css/variables.less';
-
-/deep/ .ivu-select-arrow {
-    font-size: 0.16rem !important;
-}
-
-/deep/ .ivu-select-item {
-    max-width: 6rem;
-    white-space: nowrap;
-    overflow: hidden;
-    text-overflow: ellipsis;
-}
-
-/deep/ .ivu-select-selected-value {
-    font-size: @smallFont !important;
-    height: 0.35rem !important;
-    max-width: 1.75rem !important;
-}
-
-/deep/ .ivu-select-selection {
-    height: 0.35rem !important;
-    border-radius: 0.034rem;
-}
-
-/deep/ .ivu-select-dropdown {
-    width: auto !important;
-    left: unset !important;
-    right: 0.4rem !important;
-    min-width: 2.6rem !important;
-}
-</style>

--- a/src/components/SignerBaseFilter/SignerBaseFilterTs.ts
+++ b/src/components/SignerBaseFilter/SignerBaseFilterTs.ts
@@ -1,8 +1,10 @@
 import { Component, Prop, Vue, Watch } from 'vue-property-decorator';
 import { Signer } from '@/store/Account';
 import { mapGetters } from 'vuex';
-import { SignerItem } from '../SignerSelector/SignerSelectorTs';
 
+export class SignerItem {
+    constructor(public parent: boolean, public signer: Signer, public level: number) {}
+}
 @Component({
     computed: {
         ...mapGetters({
@@ -10,7 +12,7 @@ import { SignerItem } from '../SignerSelector/SignerSelectorTs';
         }),
     },
 })
-export class SignerFilterTs extends Vue {
+export class SignerBaseFilterTs extends Vue {
     @Prop({ default: null })
     public rootSigner?: Signer;
 
@@ -23,7 +25,7 @@ export class SignerFilterTs extends Vue {
 
     public selectedSigner: string = '';
 
-    created() {
+    public created() {
         this.selectedSigner = this.currentSigner.address.plain();
     }
 
@@ -51,7 +53,7 @@ export class SignerFilterTs extends Vue {
     }
 
     @Watch('currentSigner', { immediate: true })
-    onCurrentSignerChange() {
+    public onCurrentSignerChange() {
         this.selectedSigner = this.currentSigner.address.plain();
     }
 }

--- a/src/components/SignerFilter/SignerFilter.vue
+++ b/src/components/SignerFilter/SignerFilter.vue
@@ -2,10 +2,15 @@
     <div class="transaction-filter">
         <Select v-model="selectedSigner" size="large" prefix="ios-home" @input="onSignerChange">
             <Icon slot="prefix" type="ios-people" size="0" />
-            <OptionGroup label="Multisig accounts">
-                <Option v-for="item in signers" :key="item.address.plain()" :value="item.address.plain()">
-                    {{ item.multisig ? $t('label_postfix_multisig') : '' }}
-                    {{ item.label }}
+            <Option :key="rootSigner.address.plain()" :value="rootSigner.address.plain()">
+                {{ rootSigner.label }}
+            </Option>
+            <OptionGroup v-if="multisigSigners.length" label="Multisig accounts">
+                <Option v-for="item in multisigSigners" :key="item.signer.address.plain()" :value="item.signer.address.plain()">
+                    <span :style="`display: inline-block; width: 0.1rem; margin-left: ${item.level * 0.1}rem;`">
+                        <em v-if="item.parent" class="ivu-icon ivu-icon-ios-arrow-down"></em>
+                    </span>
+                    {{ $t('label_postfix_multisig') + item.signer.label }}
                 </Option>
             </OptionGroup>
         </Select>
@@ -45,5 +50,6 @@ export default class SignerFilter extends SignerFilterTs {}
     width: auto !important;
     left: unset !important;
     right: 0.4rem !important;
+    min-width: 2.6rem !important;
 }
 </style>

--- a/src/components/SignerListFilter/SignerListFilter.vue
+++ b/src/components/SignerListFilter/SignerListFilter.vue
@@ -1,0 +1,39 @@
+<template>
+    <SignerBaseFilter :root-signer="rootSigner" @signer-change="onListSignerChange" />
+</template>
+<script lang="ts">
+import { SignerListFilterTs } from './SignerListFilterTs';
+export default class SignerListFilter extends SignerListFilterTs {}
+</script>
+<style lang="less" scoped>
+@import '../../views/resources/css/variables.less';
+
+/deep/ .ivu-select-arrow {
+    font-size: 0.16rem !important;
+}
+
+/deep/ .ivu-select-item {
+    max-width: 6rem;
+    white-space: nowrap;
+    overflow: hidden;
+    text-overflow: ellipsis;
+}
+
+/deep/ .ivu-select-selected-value {
+    font-size: @smallFont !important;
+    height: 0.35rem !important;
+    max-width: 1.75rem !important;
+}
+
+/deep/ .ivu-select-selection {
+    height: 0.35rem !important;
+    border-radius: 0.034rem;
+}
+
+/deep/ .ivu-select-dropdown {
+    width: auto !important;
+    left: unset !important;
+    right: 0.4rem !important;
+    min-width: 2.6rem !important;
+}
+</style>

--- a/src/components/SignerListFilter/SignerListFilterTs.ts
+++ b/src/components/SignerListFilter/SignerListFilterTs.ts
@@ -1,0 +1,14 @@
+import Component from 'vue-class-component';
+import { SignerBaseFilterTs } from '../SignerBaseFilter/SignerBaseFilterTs';
+// @ts-ignore
+import SignerBaseFilter from '../SignerBaseFilter/SignerBaseFilter.vue';
+
+@Component({
+    components: { SignerBaseFilter },
+})
+export class SignerListFilterTs extends SignerBaseFilterTs {
+    public onListSignerChange(newSigner: string) {
+        this.selectedSigner = newSigner;
+        this.onSignerChange();
+    }
+}

--- a/src/components/SignerSelector/SignerSelector.vue
+++ b/src/components/SignerSelector/SignerSelector.vue
@@ -4,18 +4,25 @@
             <div v-if="!noLabel">{{ $t(label) }}:</div>
         </template>
         <template v-slot:inputs>
-            <div v-if="signers && signers.length > 1" class="inputs-container select-container">
+            <div v-if="multisigSigners.length" class="select-container">
                 <Select v-model="chosenSigner" :placeholder="$t('address')" class="select-size select-style" :disabled="disabled">
-                    <Option v-for="item in signers" :key="item.address.plain()" :value="item.address.plain()">
-                        {{ item.label }}
-                        {{ item.multisig ? $t('label_postfix_multisig') : '' }}
+                    <Option :key="rootSigner.address.plain()" :value="rootSigner.address.plain()">
+                        {{ rootSigner.label }}
                     </Option>
+                    <OptionGroup v-if="multisigSigners" label="Multisig accounts">
+                        <Option v-for="item in multisigSigners" :key="item.signer.address.plain()" :value="item.signer.address.plain()">
+                            <span :style="`display: inline-block; width: 0.1rem; margin-left: ${item.level * 0.1}rem;`">
+                                <em v-if="item.parent" class="ivu-icon ivu-icon-ios-arrow-down"></em>
+                            </span>
+                            {{ item.signer.label + ' ' + $t('label_postfix_multisig') }}
+                        </Option>
+                    </OptionGroup>
                 </Select>
             </div>
             <div v-else class="signer-selector-single-signer-container">
                 <span>
-                    {{ signers[0] ? signers[0].label : '' }}
-                    {{ signers[0] && signers[0].multisig ? $t('label_postfix_multisig') : '' }}
+                    {{ rootSigner ? rootSigner.label : '' }}
+                    {{ rootSigner && rootSigner.multisig ? $t('label_postfix_multisig') : '' }}
                 </span>
             </div>
         </template>

--- a/src/components/SignerSelector/SignerSelector.vue
+++ b/src/components/SignerSelector/SignerSelector.vue
@@ -4,20 +4,8 @@
             <div v-if="!noLabel">{{ $t(label) }}:</div>
         </template>
         <template v-slot:inputs>
-            <div v-if="multisigSigners.length" class="select-container">
-                <Select v-model="chosenSigner" :placeholder="$t('address')" class="select-size select-style" :disabled="disabled">
-                    <Option :key="rootSigner.address.plain()" :value="rootSigner.address.plain()">
-                        {{ rootSigner.label }}
-                    </Option>
-                    <OptionGroup v-if="multisigSigners" label="Multisig accounts">
-                        <Option v-for="item in multisigSigners" :key="item.signer.address.plain()" :value="item.signer.address.plain()">
-                            <span :style="`display: inline-block; width: 0.1rem; margin-left: ${item.level * 0.1}rem;`">
-                                <em v-if="item.parent" class="ivu-icon ivu-icon-ios-arrow-down"></em>
-                            </span>
-                            {{ item.signer.label + ' ' + $t('label_postfix_multisig') }}
-                        </Option>
-                    </OptionGroup>
-                </Select>
+            <div v-if="rootSigner.parentSigners" class="select-container">
+                <SignerBaseFilter :root-signer="rootSigner" @signer-change="onSignerSelectorChange" />
             </div>
             <div v-else class="signer-selector-single-signer-container">
                 <span>

--- a/src/components/SignerSelector/SignerSelectorTs.ts
+++ b/src/components/SignerSelector/SignerSelectorTs.ts
@@ -18,13 +18,11 @@ import { Component, Prop, Vue } from 'vue-property-decorator';
 // @ts-ignore
 import FormRow from '@/components/FormRow/FormRow.vue';
 import { Signer } from '@/store/Account';
-
-export class SignerItem {
-    constructor(public parent: boolean, public signer: Signer, public level: number) {}
-}
+// @ts-ignore
+import SignerBaseFilter from '@/components/SignerBaseFilter/SignerBaseFilter.vue';
 
 @Component({
-    components: { FormRow },
+    components: { FormRow, SignerBaseFilter },
 })
 export class SignerSelectorTs extends Vue {
     /**
@@ -72,30 +70,9 @@ export class SignerSelectorTs extends Vue {
     get chosenSigner(): string {
         return this.value;
     }
-
-    /**
-     * @returns {SignerItem[]} multisig parent signers
-     */
-    get multisigSigners(): SignerItem[] {
-        return this.getParentSignerItems(this.rootSigner, 0);
-    }
-
-    /**
-     * Starts with the given signer, traverse multisig(parent) signers recursively and returns flat signer tree
-     * @param {Signer} signer
-     * @param {number} level
-     * @returns {SignerItem[]} Signer tree as a list
-     */
-    public getParentSignerItems(signer: Signer, level: number): SignerItem[] {
-        if (!signer?.parentSigners) {
-            return [];
-        }
-        const signerItems: SignerItem[] = [];
-        for (const parentSigner of signer.parentSigners) {
-            signerItems.push(new SignerItem(parentSigner.parentSigners?.length > 0, parentSigner, level));
-            signerItems.push(...this.getParentSignerItems(parentSigner, level + 1));
-        }
-        return signerItems;
-    }
     /// end-region computed properties getter/setter
+
+    public onSignerSelectorChange(newSigner: string) {
+        this.chosenSigner = newSigner;
+    }
 }

--- a/src/components/TableDisplay/TableDisplay.vue
+++ b/src/components/TableDisplay/TableDisplay.vue
@@ -10,8 +10,8 @@
                         <span v-show="assetType === 'mosaic'" style="margin-left: 0.1rem;">{{ $t('show_expired_mosaics') }}</span>
                         <span v-show="assetType === 'namespace'" style="margin-left: 0.1rem;">{{ $t('show_expired_namespaces') }}</span>
                     </Checkbox>
-                    <div v-if="signers.length > 1" style="min-width: 2rem;">
-                        <SignerFilter :signers="signers" @signer-change="onSignerSelectorChange" />
+                    <div v-if="currentAccountSigner.parentSigners" style="min-width: 2rem;">
+                        <SignerFilter :root-signer="currentAccountSigner" @signer-change="onSignerSelectorChange" />
                     </div>
                     <ButtonRefresh v-if="assetType !== 'metadata'" :size="24" @click="onRefresh" />
                 </div>

--- a/src/components/TableDisplay/TableDisplay.vue
+++ b/src/components/TableDisplay/TableDisplay.vue
@@ -11,7 +11,7 @@
                         <span v-show="assetType === 'namespace'" style="margin-left: 0.1rem;">{{ $t('show_expired_namespaces') }}</span>
                     </Checkbox>
                     <div v-if="currentAccountSigner.parentSigners" style="min-width: 2rem;">
-                        <SignerFilter :root-signer="currentAccountSigner" @signer-change="onSignerSelectorChange" />
+                        <SignerListFilter :root-signer="currentAccountSigner" @signer-change="onSignerSelectorChange" />
                     </div>
                     <ButtonRefresh v-if="assetType !== 'metadata'" :size="24" @click="onRefresh" />
                 </div>

--- a/src/components/TableDisplay/TableDisplayTs.ts
+++ b/src/components/TableDisplay/TableDisplayTs.ts
@@ -53,7 +53,7 @@ import { MosaicModel } from '@/core/database/entities/MosaicModel';
 import { NetworkConfigurationModel } from '@/core/database/entities/NetworkConfigurationModel';
 import { Signer } from '@/store/Account';
 // @ts-ignore
-import SignerFilter from '@/components/SignerFilter/SignerFilter.vue';
+import SignerListFilter from '@/components/SignerListFilter/SignerListFilter.vue';
 import { MetadataModel } from '@/core/database/entities/MetadataModel';
 // @ts-ignore
 import ModalMetadataUpdate from '@/views/modals/ModalMetadataUpdate/ModalMetadataUpdate.vue';
@@ -66,7 +66,7 @@ import { PageInfo } from '@/store/Transaction';
         FormExtendNamespaceDurationTransaction,
         FormMosaicSupplyChangeTransaction,
         ModalMetadataDisplay,
-        SignerFilter,
+        SignerListFilter,
         ButtonAdd,
         ModalMetadataUpdate,
         ButtonRefresh,

--- a/src/components/TableDisplay/TableDisplayTs.ts
+++ b/src/components/TableDisplay/TableDisplayTs.ts
@@ -79,7 +79,7 @@ import { PageInfo } from '@/store/Transaction';
             currentConfirmedPage: 'namespace/currentConfirmedPage',
             attachedMetadataList: 'metadata/accountMetadataList',
             networkConfiguration: 'network/networkConfiguration',
-            signers: 'account/signers',
+            currentAccountSigner: 'account/currentAccountSigner',
             currentSigner: 'account/currentSigner',
             isFetchingNamespaces: 'namespace/isFetchingNamespaces',
             isFetchingMosaics: 'mosaic/isFetchingMosaics',
@@ -134,9 +134,9 @@ export class TableDisplayTs extends Vue {
     private currentSigner: Signer;
 
     /**
-     * current signers
+     * current account signer
      */
-    public signers: Signer[];
+    public currentAccountSigner: Signer;
 
     public isFetchingNamespaces: boolean;
 

--- a/src/components/TransactionList/TransactionListFilters/TransactionListFilters.vue
+++ b/src/components/TransactionList/TransactionListFilters/TransactionListFilters.vue
@@ -4,7 +4,7 @@
             <TransactionStatusFilter />
         </div>
         <div v-if="currentAccountSigner.parentSigners" class="transaction-list-filter-container">
-            <SignerFilter :root-signer="currentAccountSigner" @signer-change="onSignerSelectorChange" />
+            <SignerListFilter :root-signer="currentAccountSigner" @signer-change="onSignerSelectorChange" />
         </div>
         <div class="button-refresh-container">
             <ButtonRefresh @click="refresh" />

--- a/src/components/TransactionList/TransactionListFilters/TransactionListFilters.vue
+++ b/src/components/TransactionList/TransactionListFilters/TransactionListFilters.vue
@@ -3,8 +3,8 @@
         <div class="transaction-list-filter-container">
             <TransactionStatusFilter />
         </div>
-        <div v-if="signers.length > 1" class="transaction-list-filter-container">
-            <SignerFilter :signers="signers" @signer-change="onSignerSelectorChange" />
+        <div v-if="currentAccountSigner.parentSigners" class="transaction-list-filter-container">
+            <SignerFilter :root-signer="currentAccountSigner" @signer-change="onSignerSelectorChange" />
         </div>
         <div class="button-refresh-container">
             <ButtonRefresh @click="refresh" />

--- a/src/components/TransactionList/TransactionListFilters/TransactionListFiltersTs.ts
+++ b/src/components/TransactionList/TransactionListFilters/TransactionListFiltersTs.ts
@@ -32,7 +32,7 @@ import { Address } from 'symbol-sdk';
     computed: {
         ...mapGetters({
             currentAccount: 'account/currentAccount',
-            signers: 'account/signers',
+            currentAccountSigner: 'account/currentAccountSigner',
         }),
     },
 })
@@ -44,9 +44,9 @@ export class TransactionListFiltersTs extends Vue {
     protected currentAccount: AccountModel;
 
     /**
-     * current signers
+     * current account signer
      */
-    public signers: Signer[];
+    public currentAccountSigner: Signer;
 
     /**
      * Hook called when the signer selector has changed

--- a/src/components/TransactionList/TransactionListFilters/TransactionListFiltersTs.ts
+++ b/src/components/TransactionList/TransactionListFilters/TransactionListFiltersTs.ts
@@ -18,7 +18,7 @@ import { mapGetters } from 'vuex';
 import { Component, Vue } from 'vue-property-decorator';
 // child components
 // @ts-ignore
-import SignerFilter from '@/components/SignerFilter/SignerFilter.vue';
+import SignerListFilter from '@/components/SignerListFilter/SignerListFilter.vue';
 // @ts-ignore
 import TransactionStatusFilter from '@/components/TransactionList/TransactionListFilters/TransactionStatusFilter/TransactionStatusFilter.vue';
 //@ts-ignore
@@ -28,7 +28,7 @@ import { AccountModel } from '@/core/database/entities/AccountModel';
 import { Address } from 'symbol-sdk';
 
 @Component({
-    components: { SignerFilter, TransactionStatusFilter, ButtonRefresh },
+    components: { SignerListFilter, TransactionStatusFilter, ButtonRefresh },
     computed: {
         ...mapGetters({
             currentAccount: 'account/currentAccount',

--- a/src/components/TransactionListOptions/TransactionListOptions.vue
+++ b/src/components/TransactionListOptions/TransactionListOptions.vue
@@ -1,6 +1,6 @@
 <template>
     <div class="transaction-list-options-container">
-        <div v-if="signers && signers.length > 1">
+        <div v-if="currentAccountSigner.parentSigners">
             <div v-if="!showSignerSelector" class="show-signer-selector">
                 <span @click="showSignerSelector = true">
                     {{ $t('see_transactions_other_account') }}
@@ -9,7 +9,7 @@
             <SignerSelector
                 v-else
                 v-model="formItems.currentSignerPubicKey"
-                :signers="signers"
+                :root-signer="currentAccountSigner"
                 :no-label="true"
                 @input="onSignerSelectorChange"
             />

--- a/src/services/MultisigService.ts
+++ b/src/services/MultisigService.ts
@@ -84,19 +84,25 @@ export class MultisigService {
         };
 
         const parentSigners: Signer[] = [];
-        for (const parentSignerAddress of currentMultisigAccountInfo?.multisigAddresses || []) {
-            parentSigners.push(
-                ...this.getSigners(
-                    knownAccounts,
-                    parentSignerAddress,
-                    multisigAccountGraph,
-                    level - 1,
-                    currentSigner.requiredCosigApproval,
-                    currentSigner.requiredCosigRemoval,
-                ),
+        if (currentMultisigAccountInfo?.multisigAddresses) {
+            for (const parentSignerAddress of currentMultisigAccountInfo.multisigAddresses) {
+                parentSigners.push(
+                    ...this.getSigners(
+                        knownAccounts,
+                        parentSignerAddress,
+                        multisigAccountGraph,
+                        level - 1,
+                        currentSigner.requiredCosigApproval,
+                        currentSigner.requiredCosigRemoval,
+                    ),
+                );
+            }
+
+            // filter the first parents
+            currentSigner.parentSigners = parentSigners.filter((ps) =>
+                currentMultisigAccountInfo.multisigAddresses.some((msa) => msa.equals(ps.address)),
             );
         }
-        currentSigner.parentSigners = parentSigners;
         return [currentSigner, ...parentSigners];
     }
 
@@ -168,51 +174,4 @@ export class MultisigService {
         const account = accounts.find((wlt) => address.plain() === wlt.address);
         return (account && account.name) || address.plain();
     }
-
-    // public getMinApprovalInMultisigTree(
-    //     multisigAccountGraphInfo: MultisigAccountInfo[][],
-    //     currentAccount: string,
-    //     selectedSigner: string,
-    //     level = multisigAccountGraphInfo.length
-    // ): number {
-    //     // 1. find the leaves non-multisig accounts and grap the currentAccount
-    //     // 2. run recursive algorithm for each multisigAddresses found
-
-    //     if (multisigAccountGraphInfo) {
-    //         multisigAccountGraphInfo.forEach((level: MultisigAccountInfo[]) => {
-    //             const levelToMap = Symbol.iterator in Object(level) ? level : [...level];
-
-    //             levelToMap.forEach((entry: MultisigAccountInfo) => {
-    //                 // if current entry is not a multisig account
-    //                 if (entry.cosignatoryAddresses.length === 0) {
-    //                     tree.push({
-    //                         address: entry.accountAddress.plain(),
-    //                         children: [],
-    //                     });
-    //                 } else {
-    //                     // find the entry matching with address matching cosignatory address and update his children
-    //                     const updateRecursively = (address, object) => (obj) => {
-    //                         if (obj.address === address) {
-    //                             obj.children.push(object);
-    //                         } else if (obj.children !== undefined) {
-    //                             obj.children.forEach(updateRecursively(address, object));
-    //                         }
-    //                     };
-    //                     // @ts-ignore
-    //                     entry.cosignatoryAddresses.forEach((addressVal) => {
-    //                         tree.forEach(
-    //                             updateRecursively(addressVal['address'], {
-    //                                 // @ts-ignore
-    //                                 address: entry.accountAddress.plain(),
-    //                                 // @ts-ignore
-    //                                 children: [],
-    //                             }),
-    //                         );
-    //                     });
-    //                 }
-    //             });
-    //         });
-    //     }
-    //     return tree;
-    // }
 }

--- a/src/services/MultisigService.ts
+++ b/src/services/MultisigService.ts
@@ -13,7 +13,7 @@
  * See the License for the specific language governing permissions and limitations under the License.
  *
  */
-import { Address, MultisigAccountGraphInfo, MultisigAccountInfo, NetworkType } from 'symbol-sdk';
+import { Address, MultisigAccountGraphInfo, MultisigAccountInfo } from 'symbol-sdk';
 // internal dependencies
 import { AccountModel } from '@/core/database/entities/AccountModel';
 import { Signer } from '@/store/Account';

--- a/src/services/TransactionFilterService.ts
+++ b/src/services/TransactionFilterService.ts
@@ -24,9 +24,9 @@ export class TransactionFilterService {
     /**
      * Filters transactions depends on selected filter options.
      * @param state for extracting transactions filter options and list filtered by group.
-     * @param currentSignerAddress selected signer address
+     * @param currentSignerAddress selected signer address(es)
      */
-    public static filter(state: TransactionState, currentSignerAddress: string): Transaction[] {
+    public static filter(state: TransactionState, currentSignerAddress: string | string[]): Transaction[] {
         const { filterOptions, transactions, confirmedTransactions, unconfirmedTransactions, partialTransactions } = state;
         if (!filterOptions.isFilterShouldBeApplied) {
             return [...transactions];
@@ -62,8 +62,9 @@ export class TransactionFilterService {
     private static filterByRecepient(
         transactions: Transaction[],
         filterOptions: TransactionFilterOptionsState,
-        currentSignerAddress: string,
+        currentSignerAddress: string | string[],
     ): Transaction[] {
+        const filteringAddresses = [].concat(currentSignerAddress);
         const recepientFilterOptions = [filterOptions.isSentSelected, filterOptions.isReceivedSelected];
         const areAllShouldBeShown: boolean = recepientFilterOptions.every((option) => !option);
         if (areAllShouldBeShown) {
@@ -81,12 +82,12 @@ export class TransactionFilterService {
             if ((transaction as any).recipientAddress && (transaction as any).recipientAddress.address) {
                 if (filterOptions.isSentSelected) {
                     if ((transaction as any).signer) {
-                        return (transaction as any).signer.address.plain() === currentSignerAddress;
+                        return filteringAddresses.some((address) => (transaction as any).signer.address.plain() === address);
                     }
                 }
 
                 if (filterOptions.isReceivedSelected) {
-                    return (transaction as any).recipientAddress.address === currentSignerAddress;
+                    return filteringAddresses.some((address) => (transaction as any).recipientAddress.address === address);
                 }
             }
         });

--- a/src/store/Account.ts
+++ b/src/store/Account.ts
@@ -53,7 +53,9 @@ export type Signer = {
     label: string;
     address: Address;
     multisig: boolean;
-    requiredCosignatures: number;
+    requiredCosigApproval: number;
+    requiredCosigRemoval?: number;
+    parentSigners?: Signer[];
 };
 
 // Account state typing
@@ -532,6 +534,7 @@ export default {
                         return infoFromGraph;
                     }),
                     catchError(() => {
+                        commit('multisigAccountGraph', []);
                         commit('multisigAccountGraphInfo', []);
                         return of([]);
                     }),
@@ -550,11 +553,9 @@ export default {
             }
 
             const signers = new MultisigService().getSigners(
-                networkType,
                 knownAccounts,
-                currentAccount,
-                currentAccountMultisigInfo,
-                multisigAccountsInfo,
+                Address.createFromRawAddress(currentAccount.address),
+                getters.multisigAccountGraph,
             );
 
             const knownAddresses = _.uniqBy(

--- a/src/store/Account.ts
+++ b/src/store/Account.ts
@@ -22,16 +22,7 @@ import { RESTService } from '@/services/RESTService';
 import * as _ from 'lodash';
 import { of, Subscription } from 'rxjs';
 import { catchError, map } from 'rxjs/operators';
-import {
-    AccountInfo,
-    AccountNames,
-    Address,
-    IListener,
-    MultisigAccountInfo,
-    NetworkType,
-    PublicAccount,
-    RepositoryFactory,
-} from 'symbol-sdk';
+import { AccountInfo, AccountNames, Address, IListener, MultisigAccountInfo, PublicAccount, RepositoryFactory } from 'symbol-sdk';
 import Vue from 'vue';
 // internal dependencies
 import { $eventBus } from '../events';
@@ -492,7 +483,6 @@ export default {
         },
 
         async LOAD_ACCOUNT_INFO({ commit, getters, rootGetters, dispatch }) {
-            const networkType: NetworkType = rootGetters['network/networkType'];
             const currentAccount: AccountModel = getters.currentAccount;
             const repositoryFactory = rootGetters['network/repositoryFactory'] as RepositoryFactory;
             const currentSignerAddress: Address = getters.currentSignerAddress;

--- a/src/views/forms/FormAccountRestrictionTransaction/FormAccountRestrictionTransaction.vue
+++ b/src/views/forms/FormAccountRestrictionTransaction/FormAccountRestrictionTransaction.vue
@@ -4,7 +4,12 @@
             <ValidationObserver v-slot="{ handleSubmit }" ref="observer" slim>
                 <form onsubmit="event.preventDefault()">
                     <!-- Transaction signer selector -->
-                    <SignerSelector v-model="formItems.signerAddress" :signers="signers" :disabled="isDeleteMode" @input="onChangeSigner" />
+                    <SignerSelector
+                        v-model="formItems.signerAddress"
+                        :root-signer="currentAccountSigner"
+                        :disabled="isDeleteMode"
+                        @input="onChangeSigner"
+                    />
 
                     <RestrictionDirectionInput v-model="formItems.direction" :disabled="isDeleteMode || directionDisabled" />
 

--- a/src/views/forms/FormAliasTransaction/FormAliasTransaction.vue
+++ b/src/views/forms/FormAliasTransaction/FormAliasTransaction.vue
@@ -2,7 +2,7 @@
     <FormWrapper>
         <ValidationObserver ref="observer" v-slot="{ handleSubmit }" slim>
             <form onsubmit="event.preventDefault()" class="form-container">
-                <SignerSelector v-model="formItems.signerAddress" :signers="signers" @input="onChangeSigner" />
+                <SignerSelector v-model="formItems.signerAddress" :root-signer="currentAccountSigner" @input="onChangeSigner" />
 
                 <!-- UNLINK alias action -->
                 <FormRow v-if="aliasAction === AliasAction.Unlink">

--- a/src/views/forms/FormMetadataCreation/FormMetadataCreation.vue
+++ b/src/views/forms/FormMetadataCreation/FormMetadataCreation.vue
@@ -6,7 +6,7 @@
                     <SignerSelector
                         v-if="!editMode"
                         v-model="formItems.signerAddress"
-                        :signers="signers"
+                        :root-signer="currentAccountSigner"
                         label="form_label_by_account"
                         @input="onChangeSigner"
                     />

--- a/src/views/forms/FormMetadataCreation/FormMetadataCreationTs.ts
+++ b/src/views/forms/FormMetadataCreation/FormMetadataCreationTs.ts
@@ -233,7 +233,7 @@ export class FormMetadataCreationTs extends FormTransactionBase {
         if (!this.selectedSigner.multisig && this.formItems.signerAddress !== this.getTargetAddress().plain()) {
             return 1;
         }
-        return this.selectedSigner.multisig ? this.multisigRequiredCosignatures : this.selectedSigner.requiredCosignatures;
+        return this.selectedSigner.requiredCosigApproval;
     }
 
     /**

--- a/src/views/forms/FormMosaicDefinitionTransaction/FormMosaicDefinitionTransaction.vue
+++ b/src/views/forms/FormMosaicDefinitionTransaction/FormMosaicDefinitionTransaction.vue
@@ -2,7 +2,7 @@
     <FormWrapper>
         <ValidationObserver v-slot="{ handleSubmit }" ref="observer" slim>
             <form onsubmit="event.preventDefault()">
-                <SignerSelector v-model="formItems.signerAddress" :signers="signers" @input="onChangeSigner" />
+                <SignerSelector v-model="formItems.signerAddress" :root-signer="currentAccountSigner" @input="onChangeSigner" />
 
                 <!-- hide supply input in aggregate transactions -->
                 <SupplyInput v-if="!isAggregate" v-model="formItems.supply" />

--- a/src/views/forms/FormMultisigAccountModificationTransaction/FormMultisigAccountModificationTransaction.vue
+++ b/src/views/forms/FormMultisigAccountModificationTransaction/FormMultisigAccountModificationTransaction.vue
@@ -23,7 +23,12 @@
                     </template>
 
                     <template v-slot:inputs>
-                        <SignerSelector v-model="formItems.signerAddress" :signers="signers" :no-label="true" @input="onChangeSigner" />
+                        <SignerSelector
+                            v-model="formItems.signerAddress"
+                            :root-signer="currentAccountSigner"
+                            :no-label="true"
+                            @input="onChangeSigner"
+                        />
                     </template>
                 </FormRow>
 

--- a/src/views/forms/FormMultisigAccountModificationTransaction/FormMultisigAccountModificationTransactionTs.ts
+++ b/src/views/forms/FormMultisigAccountModificationTransaction/FormMultisigAccountModificationTransactionTs.ts
@@ -432,7 +432,7 @@ export class FormMultisigAccountModificationTransactionTs extends FormTransactio
         let reqCosignatures = 1;
 
         if (this.addressDeletions.length > 0) {
-            reqCosignatures = this.multisigRequiredCosignaturesForRemoval;
+            reqCosignatures = this.selectedSigner.requiredCosigRemoval;
         }
 
         if (this.addressAdditions.length > 0) {
@@ -449,30 +449,10 @@ export class FormMultisigAccountModificationTransactionTs extends FormTransactio
 
         if (!this.addressDeletions.length && !this.addressAdditions.length) {
             // only removal or approval changes, no address additions or deletions
-            reqCosignatures = this.multisigRequiredCosignatures;
+            reqCosignatures = this.selectedSigner.requiredCosigApproval;
         }
 
         return reqCosignatures;
-    }
-
-    /**
-        multilevel multisig calculates `max(minRemoval)` in the tree from selectedSigner to currentAccount
-     */
-    private get multisigRequiredCosignaturesForRemoval(): number {
-        // travel every level from current account to the current signer in the tree and return the max minRemoval found
-        if (this.multisigAccountGraphInfo?.length <= 2) {
-            // it is not a multilevel multisig then return current minRemoval
-            return this.currentSignerMultisigInfo?.minRemoval || 0;
-        }
-        let maxOfMinRemovals = 1;
-        for (let inx = 0; inx < this.multisigAccountGraphInfo.length; inx++) {
-            const currentLevel: MultisigAccountInfo = this.multisigAccountGraphInfo[inx];
-            maxOfMinRemovals = Math.max(currentLevel.minRemoval, maxOfMinRemovals);
-            if (currentLevel.accountAddress.plain() === this.selectedSigner.address.plain()) {
-                break;
-            }
-        }
-        return maxOfMinRemovals;
     }
 
     /**

--- a/src/views/forms/FormNamespaceRegistrationTransaction/FormNamespaceRegistrationTransaction.vue
+++ b/src/views/forms/FormNamespaceRegistrationTransaction/FormNamespaceRegistrationTransaction.vue
@@ -3,7 +3,7 @@
         <FormWrapper class="namespace-transaction-form-wrapper">
             <ValidationObserver v-slot="{ handleSubmit }" ref="observer" slim>
                 <form onsubmit="event.preventDefault()" class="form-container mt-3 create-namespace-form">
-                    <SignerSelector v-model="formItems.signerAddress" :signers="signers" @input="onChangeSigner" />
+                    <SignerSelector v-model="formItems.signerAddress" :root-signer="currentAccountSigner" @input="onChangeSigner" />
                     <FormRow>
                         <template v-slot:label> {{ $t('form_label_registration_type') }}: </template>
                         <template v-slot:inputs>

--- a/src/views/forms/FormPersistentDelegationRequestTransaction/FormPersistentDelegationRequestTransaction.vue
+++ b/src/views/forms/FormPersistentDelegationRequestTransaction/FormPersistentDelegationRequestTransaction.vue
@@ -37,7 +37,7 @@
                         </div>
 
                         <!-- Transaction signer selector -->
-                        <SignerSelector v-model="formItems.signerAddress" :signers="signers" @input="onChangeSigner" />
+                        <SignerSelector v-model="formItems.signerAddress" :root-signer="currentAccountSigner" @input="onChangeSigner" />
 
                         <NetworkNodeSelector
                             v-model="formItems.nodeModel"

--- a/src/views/forms/FormTransactionBase/FormTransactionBase.ts
+++ b/src/views/forms/FormTransactionBase/FormTransactionBase.ts
@@ -46,7 +46,6 @@ import { NetworkConfigurationModel } from '@/core/database/entities/NetworkConfi
             transactionFees: 'network/transactionFees',
             isOfflineMode: 'network/isOfflineMode',
             multisigAccountGraphInfo: 'account/multisigAccountGraphInfo',
-            multisigAccountGraph: 'account/multisigAccountGraph',
         }),
     },
 })
@@ -144,8 +143,6 @@ export class FormTransactionBase extends Vue {
     protected isOfflineMode: boolean;
 
     protected multisigAccountGraphInfo: MultisigAccountInfo[];
-
-    protected multisigAccountGraph: MultisigAccountInfo[][];
 
     /**
      * Type the ValidationObserver refs

--- a/src/views/forms/FormTransactionBase/FormTransactionBase.ts
+++ b/src/views/forms/FormTransactionBase/FormTransactionBase.ts
@@ -33,6 +33,7 @@ import { NetworkConfigurationModel } from '@/core/database/entities/NetworkConfi
             defaultFee: 'app/defaultFee',
             currentAccount: 'account/currentAccount',
             selectedSigner: 'account/currentSigner',
+            currentAccountSigner: 'account/currentAccountSigner',
             currentSignerPublicKey: 'account/currentSignerPublicKey',
             currentSignerAddress: 'account/currentSignerAddress',
             currentSignerMultisigInfo: 'account/currentSignerMultisigInfo',
@@ -129,6 +130,8 @@ export class FormTransactionBase extends Vue {
     public currentSigner: PublicAccount;
 
     public signers: Signer[];
+
+    public currentAccountSigner: Signer;
 
     public networkCurrency: NetworkCurrencyModel;
 

--- a/src/views/forms/FormTransactionBase/FormTransactionBase.ts
+++ b/src/views/forms/FormTransactionBase/FormTransactionBase.ts
@@ -45,6 +45,7 @@ import { NetworkConfigurationModel } from '@/core/database/entities/NetworkConfi
             transactionFees: 'network/transactionFees',
             isOfflineMode: 'network/isOfflineMode',
             multisigAccountGraphInfo: 'account/multisigAccountGraphInfo',
+            multisigAccountGraph: 'account/multisigAccountGraph',
         }),
     },
 })
@@ -140,6 +141,8 @@ export class FormTransactionBase extends Vue {
     protected isOfflineMode: boolean;
 
     protected multisigAccountGraphInfo: MultisigAccountInfo[];
+
+    protected multisigAccountGraph: MultisigAccountInfo[][];
 
     /**
      * Type the ValidationObserver refs
@@ -305,26 +308,7 @@ export class FormTransactionBase extends Vue {
     }
 
     protected get requiredCosignatures() {
-        return this.isMultisigMode() ? this.multisigRequiredCosignatures : this.selectedSigner.requiredCosignatures;
-    }
-
-    /**
-     * travel every level from current account to the current signer in the tree and return the max minApproval found
-     */
-    protected get multisigRequiredCosignatures(): number {
-        if (this.multisigAccountGraphInfo?.length <= 2) {
-            // it is not a multilevel multisig then return current minApproval
-            return this.currentSignerMultisigInfo?.minApproval || 0;
-        }
-        let maxOfMinApprovals = 1;
-        for (let inx = 0; inx < this.multisigAccountGraphInfo.length; inx++) {
-            const currentLevel: MultisigAccountInfo = this.multisigAccountGraphInfo[inx];
-            maxOfMinApprovals = Math.max(currentLevel.minApproval, maxOfMinApprovals);
-            if (currentLevel.accountAddress.plain() === this.selectedSigner.address.plain()) {
-                break;
-            }
-        }
-        return maxOfMinApprovals;
+        return this.selectedSigner.requiredCosigApproval;
     }
 
     /**

--- a/src/views/forms/FormTransferTransaction/FormTransferTransaction.vue
+++ b/src/views/forms/FormTransferTransaction/FormTransferTransaction.vue
@@ -13,7 +13,7 @@
                     <SignerSelector
                         v-if="!hideSigner && !isOfflineMode"
                         v-model="formItems.signerAddress"
-                        :signers="signers"
+                        :root-signer="currentAccountSigner"
                         @input="onChangeSigner"
                     />
                     <AccountSignerSelector v-if="!hideSigner && isOfflineMode" />

--- a/src/views/forms/FormTransferTransaction/FormTransferTransactionTs.ts
+++ b/src/views/forms/FormTransferTransaction/FormTransferTransactionTs.ts
@@ -736,7 +736,7 @@ export class FormTransferTransactionTs extends FormTransactionBase {
             this.networkType,
             this.networkConfiguration,
             this.transactionFees,
-            this.currentSignerMultisigInfo ? this.currentSignerMultisigInfo.minApproval : this.selectedSigner.requiredCosignatures,
+            this.currentSignerMultisigInfo ? this.currentSignerMultisigInfo.minApproval : this.selectedSigner.requiredCosigApproval,
         );
     }
 

--- a/src/views/forms/FormTransferTransaction/FormTransferTransactionTs.ts
+++ b/src/views/forms/FormTransferTransaction/FormTransferTransactionTs.ts
@@ -736,7 +736,7 @@ export class FormTransferTransactionTs extends FormTransactionBase {
             this.networkType,
             this.networkConfiguration,
             this.transactionFees,
-            this.currentSignerMultisigInfo ? this.currentSignerMultisigInfo.minApproval : this.selectedSigner.requiredCosigApproval,
+            this.selectedSigner.requiredCosigApproval,
         );
     }
 


### PR DESCRIPTION
fixes #1687 , #1688, #1697 

Changes:
* `Signer` class holds references to its parents as a tree (`parentSigners`), all `Signer`'s  `requiredCosigApproval` and `requiredCosigRemoval`s are pre-calculated while constructing the tree. This info is used to decide on creating AGGREGATE_COMPLETE when there is only 1 cosigner needed to approve(`minApproval === 1`).
* SignerSelector and SignerFilter dropdowns show signers as grouped and in a tree structure (starting from the leave(current account) going down to the root signer (supporting multiple, multi-level multisig structures)
![image](https://user-images.githubusercontent.com/6256269/132686864-c5ace1bc-f870-40fb-9cb2-54cc97c1bcf9.png)

* SignerSelector and SignerFilter components refactored to use the same base and became => `SignerSelector`, `SignerListFilter` => extending/using  `SignerBaseFilter`
* Several bugs noticed during the testing are fixed.
  