### PR TITLE
fix: showing a warning on transactions detail/cosignature modal

### DIFF
--- a/src/language/en-US.json
+++ b/src/language/en-US.json
@@ -1126,5 +1126,8 @@
     "welcome_to_symbol": "Welcome to Symbol",
     "word": "Word",
     "ws_connection_failed": "The wallet cannot monitor the activities of your account on the Symbol chain. Please try selecting a different node.",
-    "x_seconds": "{seconds}s."
+    "x_seconds": "{seconds}s.",
+    "transaction_cosignature_warning_dont_sign": "Do not sign if you do not know the origin of the transaction.",
+    "transaction_cosignature_warning_unknown_cosigner": "You are about to sign a transaction that was not created by you.",
+    "transaction_cosignature_warning_proceed": "I understand and wish to proceed."
 }

--- a/src/language/ja-JP.json
+++ b/src/language/ja-JP.json
@@ -1126,5 +1126,8 @@
     "welcome_to_symbol": "ようこそ Symbol へ",
     "word": "文字",
     "ws_connection_failed": "ウォレットはSymbolチェーン上のアカウントに関するアクティビティを監視できません。別のノードを選択してみてください。",
-    "x_seconds": "{seconds} 秒"
+    "x_seconds": "{seconds} 秒",
+    "transaction_cosignature_warning_unknown_cosigner": "この署名を求めるトランザクションはあなたが作成したものではありません",
+    "transaction_cosignature_warning_dont_sign": "心当たりがなければ署名しないでください",
+    "transaction_cosignature_warning_proceed": "確認しましたので署名に同意します"
 }

--- a/src/language/ru-RU.json
+++ b/src/language/ru-RU.json
@@ -1126,5 +1126,8 @@
     "welcome_to_symbol": "Добро пожаловать в Symbol",
     "word": "Слово",
     "ws_connection_failed": "Кошелек не может отслеживать действия вашего аккаунта в цепочке Symbol. Пожалуйста, попробуйте выбрать другую ноду.",
-    "x_seconds": "{seconds}s."
+    "x_seconds": "{seconds}s.",
+    "transaction_cosignature_warning_unknown_cosigner": "Вы собираетесь подписать транзакцию, созданную не вами.",
+    "transaction_cosignature_warning_dont_sign": "Не подписывайте транзакцию, если вы не знаете её происхождение!",
+    "transaction_cosignature_warning_proceed": "Я понимаю и хочу продолжить."
 }

--- a/src/language/zh-CN.json
+++ b/src/language/zh-CN.json
@@ -1126,5 +1126,8 @@
     "welcome_to_symbol": "欢迎使用Symbol",
     "word": "字",
     "ws_connection_failed": "钱包无法监视您在Symbol链上的帐户活动。请尝试选择其他节点。",
-    "x_seconds": "{seconds}秒"
+    "x_seconds": "{seconds}秒",
+    "transaction_cosignature_warning_unknown_cosigner": "您即将签署的交易不是您创建的。",
+    "transaction_cosignature_warning_dont_sign": "不知道交易来源的千万不要签！",
+    "transaction_cosignature_warning_proceed": "我理解并请继续。"
 }

--- a/src/services/MultisigService.ts
+++ b/src/services/MultisigService.ts
@@ -170,6 +170,27 @@ export class MultisigService {
             return addresses;
         }
     }
+
+    /**
+     * Checks if the given address in the given multisignature tree
+     * @param multisigAccountGraph Multisig tree structure
+     * @param address Address to search in the tree
+     * @returns
+     */
+    public static isAddressInMultisigTree(multisigAccountGraph: Map<number, MultisigAccountInfo[]>, address: string): boolean {
+        for (const [l, levelAccounts] of multisigAccountGraph) {
+            for (const levelAccount of levelAccounts) {
+                if (
+                    levelAccount.accountAddress.plain() === address ||
+                    levelAccount.cosignatoryAddresses?.some((c) => c.plain() === address)
+                ) {
+                    return true;
+                }
+            }
+        }
+        return false;
+    }
+
     private getAccountLabel(address: Address, accounts: AccountModel[]): string {
         const account = accounts.find((wlt) => address.plain() === wlt.address);
         return (account && account.name) || address.plain();

--- a/src/views/modals/ModalTransactionCosignature/ModalTransactionCosignature.less
+++ b/src/views/modals/ModalTransactionCosignature/ModalTransactionCosignature.less
@@ -19,6 +19,17 @@
                 padding-top: 0.2rem;
                 text-align: justify;
             }
+            .warning-row {
+                margin-bottom: 0.1rem;
+            }
+            .emphasis {
+                color: @primary;
+                font-weight: @boldest;
+            }
+
+            .warning .ivu-alert-icon {
+                font-size: 0.26rem;
+            }
         }
 
         .explain-qr {

--- a/src/views/modals/ModalTransactionCosignature/ModalTransactionCosignature.vue
+++ b/src/views/modals/ModalTransactionCosignature/ModalTransactionCosignature.vue
@@ -53,10 +53,33 @@
                         <div class="explain">
                             <span class="subtitle">{{ $t('transaction_needs_cosignature') }}</span>
                             <p>{{ $t('transaction_needs_cosignature_explain') }}</p>
+                            <span v-if="!initiatedByMsigCosigner" class="warning">
+                                <Alert type="warning" show-icon>
+                                    <div class="warning-row">
+                                        <span class="emphasis"
+                                            >You are about to sign a transaction which was not created by you or a known cosigner.</span
+                                        >
+                                        Please review the details carefully!
+                                    </div>
+                                    <div class="warning-row">
+                                        Do not sign if you do not know the origin of the transaction.
+                                    </div>
+                                    <div class="inputs-container emphasis">
+                                        <Checkbox v-model="wantToProceed">
+                                            {{ `I understand and want to proceed.` }}
+                                        </Checkbox>
+                                    </div>
+                                </Alert>
+                            </span>
                         </div>
 
                         <HardwareConfirmationButton v-if="isUsingHardwareWallet" @success="onSigner" @error="onError" />
-                        <FormProfileUnlock v-else @success="onAccountUnlocked" @error="onError" />
+                        <FormProfileUnlock
+                            v-else
+                            :disabled="!initiatedByMsigCosigner && !wantToProceed"
+                            @success="onAccountUnlocked"
+                            @error="onError"
+                        />
                     </div>
                 </div>
                 <div v-else-if="expired">

--- a/src/views/modals/ModalTransactionCosignature/ModalTransactionCosignature.vue
+++ b/src/views/modals/ModalTransactionCosignature/ModalTransactionCosignature.vue
@@ -53,20 +53,17 @@
                         <div class="explain">
                             <span class="subtitle">{{ $t('transaction_needs_cosignature') }}</span>
                             <p>{{ $t('transaction_needs_cosignature_explain') }}</p>
-                            <span v-if="!initiatedByMsigCosigner" class="warning">
+                            <span v-if="!hideCosignerWarning" class="warning">
                                 <Alert type="warning" show-icon>
-                                    <div class="warning-row">
-                                        <span class="emphasis"
-                                            >You are about to sign a transaction which was not created by you or a known cosigner.</span
-                                        >
-                                        Please review the details carefully!
+                                    <div class="warning-row emphasis">
+                                        {{ $t('transaction_cosignature_warning_unknown_cosigner') }}
                                     </div>
                                     <div class="warning-row">
-                                        Do not sign if you do not know the origin of the transaction.
+                                        {{ $t('transaction_cosignature_warning_dont_sign') }}
                                     </div>
                                     <div class="inputs-container emphasis">
                                         <Checkbox v-model="wantToProceed">
-                                            {{ `I understand and want to proceed.` }}
+                                            {{ $t('transaction_cosignature_warning_proceed') }}
                                         </Checkbox>
                                     </div>
                                 </Alert>
@@ -76,7 +73,7 @@
                         <HardwareConfirmationButton v-if="isUsingHardwareWallet" @success="onSigner" @error="onError" />
                         <FormProfileUnlock
                             v-else
-                            :disabled="!initiatedByMsigCosigner && !wantToProceed"
+                            :disabled="!hideCosignerWarning && !wantToProceed"
                             @success="onAccountUnlocked"
                             @error="onError"
                         />

--- a/src/views/modals/ModalTransactionCosignature/ModalTransactionCosignatureTs.ts
+++ b/src/views/modals/ModalTransactionCosignature/ModalTransactionCosignatureTs.ts
@@ -65,6 +65,7 @@ import { MultisigService } from '@/services/MultisigService';
             generationHash: 'network/generationHash',
             currentAccountMultisigInfo: 'account/currentAccountMultisigInfo',
             multisigAccountGraphInfo: 'account/multisigAccountGraphInfo',
+            multisigAccountGraph: 'account/multisigAccountGraph',
         }),
     },
 })
@@ -124,10 +125,19 @@ export class ModalTransactionCosignatureTs extends Vue {
      */
     public currentAccountMultisigInfo: MultisigAccountInfo;
 
+    public multisigAccountGraph: Map<number, MultisigAccountInfo[]>;
+
     /**
      * Whether transaction has expired
      */
     public expired: boolean = false;
+
+    /**
+     * Whether transaction is initiated by multisig parent
+     */
+    public initiatedByMsigCosigner = false;
+
+    public wantToProceed = false;
 
     /// region computed properties
     /**
@@ -223,6 +233,10 @@ export class ModalTransactionCosignatureTs extends Vue {
             const multisignService = new MultisigService();
             const mutlisigChildrenTree = multisignService.getMultisigChildren(this.multisigAccountGraphInfo);
             const mutlisigChildren = multisignService.getMultisigChildrenAddresses(this.multisigAccountGraphInfo);
+
+            this.initiatedByMsigCosigner =
+                mutlisigChildrenTree &&
+                MultisigService.isAddressInMultisigTree(this.multisigAccountGraph, this.transaction.signer.address.plain());
 
             this.transaction.innerTransactions.forEach((t) => {
                 if (t.type === TransactionType.MULTISIG_ACCOUNT_MODIFICATION.valueOf()) {


### PR DESCRIPTION
fixes #1719 
showing a warning on transactions detail/cosignature modal and getting ack when the tx is announced by 3rd party account

WIP: 
* texts need to be localized
* all the transaction types need to be tested (restriction, metadata etc)

![image](https://user-images.githubusercontent.com/6256269/135281804-979e76e5-0d8d-4d5b-86f9-2db69ad8d0c6.png)

https://www.loom.com/share/57b7dcfb2dd14f12b7067eaa999a57e3
