### PR TITLE
fix #1767

### DIFF
--- a/src/services/NetworkService.ts
+++ b/src/services/NetworkService.ts
@@ -173,7 +173,7 @@ export class NetworkService {
      * It checks if a node has Websocket functioning properly to subscribe.
      * @param url the url.
      */
-    public async checkWebsocketConnection(url: string, isOffline: boolean) {
+    public async checkWebsocketConnection(url: string) {
         const webSocket = new WebSocket(url);
         let websocketConnectionStatus: boolean = false;
         webSocket.onmessage = function (e) {

--- a/src/services/NetworkService.ts
+++ b/src/services/NetworkService.ts
@@ -168,4 +168,23 @@ export class NetworkService {
                   websocketInjected: WebSocket,
               });
     }
+    /**
+     * It checks if a node has Websocket functioning properly to subscribe.
+     * @param url the url.
+     */
+    public checkWebsocketConnection(url: string): boolean {
+        const webSocket = new WebSocket(url);
+        let websocketConnectionStatus: boolean = false;
+        webSocket.onmessage = function (e) {
+            websocketConnectionStatus = e.toString().indexOf('failed') !== -1;
+        };
+        // trying port 3000 if the node has :3001 opened but failed to subscribe to WS.
+        if (!websocketConnectionStatus && url.indexOf(':3001') !== -1) {
+            const webSocketHttp = new WebSocket(url.replace(':3001', ':3000'));
+            webSocketHttp.onmessage = function (e) {
+                websocketConnectionStatus = e.toString().indexOf('failed') !== -1;
+            };
+        }
+        return websocketConnectionStatus;
+    }
 }

--- a/src/store/Network.ts
+++ b/src/store/Network.ts
@@ -315,13 +315,13 @@ export default {
                 let wsConnection = undefined;
                 if (navigator.onLine && !isOffline) {
                     wsUrl = nodeNetworkModelResult.repositoryFactory.createListener().url;
-                    wsConnection = await networkService.checkWebsocketConnection(wsUrl, isOffline);
+                    wsConnection = await networkService.checkWebsocketConnection(wsUrl);
                     if (!wsConnection.status && wsConnection.sslNode) {
                         nodeNetworkModelResult = await networkService
                             .getNetworkModel(newCandidateUrl.replace('https', 'http').replace('3001', '3000'), networkType, isOffline)
                             .toPromise();
                         wsUrl = nodeNetworkModelResult.repositoryFactory.createListener().url;
-                        wsConnection = await networkService.checkWebsocketConnection(wsUrl, isOffline);
+                        wsConnection = await networkService.checkWebsocketConnection(wsUrl);
                     }
                 }
                 if (
@@ -357,9 +357,9 @@ export default {
                         .toPromise();
                     let wsUrl = undefined;
                     let wsConnection = undefined;
-                    if (navigator.onLine  && !isOffline) {
+                    if (navigator.onLine && !isOffline) {
                         wsUrl = nodeNetworkModelResult.repositoryFactory.createListener().url;
-                        wsConnection = await networkService.checkWebsocketConnection(wsUrl, isOffline);
+                        wsConnection = await networkService.checkWebsocketConnection(wsUrl);
                         if (!wsConnection.status && wsConnection.sslNode) {
                             nodeNetworkModelResult = await networkService
                                 .getNetworkModel(
@@ -369,7 +369,7 @@ export default {
                                 )
                                 .toPromise();
                             wsUrl = nodeNetworkModelResult.repositoryFactory.createListener().url;
-                            wsConnection = await networkService.checkWebsocketConnection(wsUrl, isOffline);
+                            wsConnection = await networkService.checkWebsocketConnection(wsUrl);
                         }
                     }
                     if (

--- a/src/store/Network.ts
+++ b/src/store/Network.ts
@@ -311,13 +311,25 @@ export default {
                     progressTotalNumOfNodes: 1,
                 });
                 nodeNetworkModelResult = await networkService.getNetworkModel(newCandidateUrl, networkType, isOffline).toPromise();
-                const wsUrl = nodeNetworkModelResult.repositoryFactory.createListener().url;
-                const wsConnectionStatus = networkService.checkWebsocketConnection(wsUrl);
+                let wsUrl = undefined;
+                let wsConnection = undefined;
+                if (navigator.onLine && !isOffline) {
+                    wsUrl = nodeNetworkModelResult.repositoryFactory.createListener().url;
+                    wsConnection = await networkService.checkWebsocketConnection(wsUrl, isOffline);
+                    if (!wsConnection.status && wsConnection.sslNode) {
+                        nodeNetworkModelResult = await networkService
+                            .getNetworkModel(newCandidateUrl.replace('https', 'http').replace('3001', '3000'), networkType, isOffline)
+                            .toPromise();
+                        wsUrl = nodeNetworkModelResult.repositoryFactory.createListener().url;
+                        wsConnection = await networkService.checkWebsocketConnection(wsUrl, isOffline);
+                    }
+                }
                 if (
                     nodeNetworkModelResult &&
                     nodeNetworkModelResult.networkModel &&
                     nodeNetworkModelResult.networkModel.networkType === networkType &&
-                    wsConnectionStatus
+                    wsConnection &&
+                    wsConnection.status
                 ) {
                     await dispatch('CONNECT_TO_A_VALID_NODE', nodeNetworkModelResult);
                 } else {
@@ -343,13 +355,29 @@ export default {
                     nodeNetworkModelResult = await networkService
                         .getNetworkModel(currentProfile.selectedNodeUrlToConnect, networkType, isOffline)
                         .toPromise();
-                    const wsUrl = nodeNetworkModelResult.repositoryFactory.createListener().url;
-                    const wsConnectionStatus = networkService.checkWebsocketConnection(wsUrl);
+                    let wsUrl = undefined;
+                    let wsConnection = undefined;
+                    if (navigator.onLine  && !isOffline) {
+                        wsUrl = nodeNetworkModelResult.repositoryFactory.createListener().url;
+                        wsConnection = await networkService.checkWebsocketConnection(wsUrl, isOffline);
+                        if (!wsConnection.status && wsConnection.sslNode) {
+                            nodeNetworkModelResult = await networkService
+                                .getNetworkModel(
+                                    currentProfile.selectedNodeUrlToConnect.replace('https', 'http').replace('3001', '3000'),
+                                    networkType,
+                                    isOffline,
+                                )
+                                .toPromise();
+                            wsUrl = nodeNetworkModelResult.repositoryFactory.createListener().url;
+                            wsConnection = await networkService.checkWebsocketConnection(wsUrl, isOffline);
+                        }
+                    }
                     if (
                         nodeNetworkModelResult &&
                         nodeNetworkModelResult.repositoryFactory &&
                         nodeNetworkModelResult.networkModel.networkType === currentProfile.networkType &&
-                        wsConnectionStatus
+                        wsConnection &&
+                        wsConnection.status
                     ) {
                         await dispatch('CONNECT_TO_A_VALID_NODE', nodeNetworkModelResult);
                         nodeFound = true;

--- a/src/store/Network.ts
+++ b/src/store/Network.ts
@@ -340,10 +340,16 @@ export default {
                     nodeNetworkModelResult = await networkService
                         .getNetworkModel(currentProfile.selectedNodeUrlToConnect, networkType, isOffline)
                         .toPromise();
+                    const webSocket = new WebSocket(nodeNetworkModelResult.repositoryFactory.createListener().url);
+                    let websocketConnection: boolean = false;
+                    webSocket.onmessage = function (e) {
+                        websocketConnection = e.toString().indexOf('failed') !== -1;
+                    };
                     if (
                         nodeNetworkModelResult &&
                         nodeNetworkModelResult.repositoryFactory &&
-                        nodeNetworkModelResult.networkModel.networkType === currentProfile.networkType
+                        nodeNetworkModelResult.networkModel.networkType === currentProfile.networkType &&
+                        websocketConnection
                     ) {
                         await dispatch('CONNECT_TO_A_VALID_NODE', nodeNetworkModelResult);
                         nodeFound = true;

--- a/src/store/Network.ts
+++ b/src/store/Network.ts
@@ -311,10 +311,13 @@ export default {
                     progressTotalNumOfNodes: 1,
                 });
                 nodeNetworkModelResult = await networkService.getNetworkModel(newCandidateUrl, networkType, isOffline).toPromise();
+                const wsUrl = nodeNetworkModelResult.repositoryFactory.createListener().url;
+                const wsConnectionStatus = networkService.checkWebsocketConnection(wsUrl);
                 if (
                     nodeNetworkModelResult &&
                     nodeNetworkModelResult.networkModel &&
-                    nodeNetworkModelResult.networkModel.networkType === networkType
+                    nodeNetworkModelResult.networkModel.networkType === networkType &&
+                    wsConnectionStatus
                 ) {
                     await dispatch('CONNECT_TO_A_VALID_NODE', nodeNetworkModelResult);
                 } else {
@@ -340,16 +343,13 @@ export default {
                     nodeNetworkModelResult = await networkService
                         .getNetworkModel(currentProfile.selectedNodeUrlToConnect, networkType, isOffline)
                         .toPromise();
-                    const webSocket = new WebSocket(nodeNetworkModelResult.repositoryFactory.createListener().url);
-                    let websocketConnection: boolean = false;
-                    webSocket.onmessage = function (e) {
-                        websocketConnection = e.toString().indexOf('failed') !== -1;
-                    };
+                    const wsUrl = nodeNetworkModelResult.repositoryFactory.createListener().url;
+                    const wsConnectionStatus = networkService.checkWebsocketConnection(wsUrl);
                     if (
                         nodeNetworkModelResult &&
                         nodeNetworkModelResult.repositoryFactory &&
                         nodeNetworkModelResult.networkModel.networkType === currentProfile.networkType &&
-                        websocketConnection
+                        wsConnectionStatus
                     ) {
                         await dispatch('CONNECT_TO_A_VALID_NODE', nodeNetworkModelResult);
                         nodeFound = true;


### PR DESCRIPTION
Currently, when a node allows SSL/port:3001 and does not provide a stable connection for WebSockets subscription the wallet fails to login.

Proposed solution:
fallback for HTTP/port:3000 and retry the connection, in case it fails wallet should fall-back to a different node seeking a valid Websocets connection.