### PR TITLE
fix #1767

### DIFF
--- a/__tests__/database/storage/NodeModelStorage.spec.ts
+++ b/__tests__/database/storage/NodeModelStorage.spec.ts
@@ -45,7 +45,7 @@ describe('storage/ProfileModelStorage.spec ==>', () => {
     describe('constructor() should', () => {
         test('Should save nodes by profile name', () => {
             const nodes = {
-                version: 11,
+                version: 12,
                 data: {
                     [fakeProfile.profileName]: [fakeNode],
                 },

--- a/src/config/NetworkConfig.ts
+++ b/src/config/NetworkConfig.ts
@@ -53,7 +53,7 @@ export interface NetworkConfig {
 export const defaultTestnetNetworkConfig: NetworkConfig = {
     explorerUrl: 'https://testnet.symbol.fyi/',
     faucetUrl: 'https://testnet.symbol.tools/',
-    statisticServiceUrl: 'https://testnet.symbol.services/',
+    statisticServiceUrl: 'https://testnet.symbol.services',
     defaultNetworkType: 152,
     networkConfigurationDefaults: {
         maxMosaicDivisibility: 6,
@@ -81,7 +81,7 @@ export const defaultTestnetNetworkConfig: NetworkConfig = {
 export const defaultMainnetNetworkConfig: NetworkConfig = {
     explorerUrl: 'https://symbol.fyi/',
     faucetUrl: 'https://faucet.mainnet.symboldev.network/',
-    statisticServiceUrl: 'https://symbol.services/',
+    statisticServiceUrl: 'https://symbol.services',
     defaultNetworkType: 104,
     networkConfigurationDefaults: {
         maxMosaicDivisibility: 6,

--- a/src/core/database/storage/NodeModelStorage.ts
+++ b/src/core/database/storage/NodeModelStorage.ts
@@ -72,6 +72,10 @@ export class NodeModelStorage extends VersionedObjectStorage<Record<string, Node
                     description: 'Reset nodes to load from statistics service',
                     migrate: () => undefined,
                 },
+                {
+                    description: 'Reset nodes for websocket url update',
+                    migrate: () => undefined,
+                },
             ],
         });
     }

--- a/src/services/NetworkService.ts
+++ b/src/services/NetworkService.ts
@@ -25,7 +25,7 @@ import { combineLatest, defer, EMPTY, from, Observable } from 'rxjs';
 import { catchError, flatMap, map, tap } from 'rxjs/operators';
 import { NetworkConfiguration, NetworkType, RepositoryFactory, RepositoryFactoryHttp } from 'symbol-sdk';
 import { OfflineRepositoryFactory } from '@/services/offline/OfflineRepositoryFactory';
-
+import { CommonHelpers } from '@/core/utils/CommonHelpers';
 /**
  * The service in charge of loading and caching anything related to Network from Rest.
  * The cache is done by storing the payloads in SimpleObjectStorage.
@@ -56,11 +56,12 @@ export class NetworkService {
         nodeUrl: string,
         defaultNetworkType: NetworkType = NetworkType.TEST_NET,
         isOffline = false,
+        nodeWsUrl?: string,
     ): Observable<{
         networkModel: NetworkModel;
         repositoryFactory: RepositoryFactory;
     }> {
-        return from(this.createRepositoryFactory(nodeUrl, isOffline, defaultNetworkType)).pipe(
+        return from(this.createRepositoryFactory(nodeUrl, isOffline, defaultNetworkType, nodeWsUrl)).pipe(
             flatMap(({ url, repositoryFactory }) => {
                 return repositoryFactory.getGenerationHash().pipe(
                     flatMap((generationHash) => {
@@ -110,9 +111,10 @@ export class NetworkService {
         url: string,
         isOffline = false,
         networkType = NetworkType.TEST_NET,
+        nodeWsUrl?: string,
     ): Observable<{ url: string; repositoryFactory: RepositoryFactory }> {
         // console.log(`Testing ${url}`);
-        const repositoryFactory = NetworkService.createRepositoryFactory(url, isOffline, networkType);
+        const repositoryFactory = NetworkService.createRepositoryFactory(url, isOffline, networkType, nodeWsUrl);
         return defer(() => {
             return repositoryFactory.getGenerationHash();
         }).pipe(
@@ -155,16 +157,35 @@ export class NetworkService {
     public reset(generationHash: string) {
         this.storage.remove(generationHash);
     }
+    /**
+     * It checks if a node has Websocket functioning properly to subscribe.
+     * @param url the url.
+     * @param timeout number
+     */
+    public async checkWebsocketConnection(url: string, timeout: number): Promise<boolean> {
+        const webSocket = new WebSocket(url);
+        let websocketConnectionStatus: boolean = false;
+        webSocket.onmessage = function (e: any) {
+            websocketConnectionStatus = e.currentTarget.readyState == 1;
+        };
+        await CommonHelpers.sleep(timeout);
+        return websocketConnectionStatus;
+    }
 
     /**
      * It creates the RepositoryFactory used to build the http repository/clients and listeners.
      * @param url the url.
      */
-    public static createRepositoryFactory(url: string, isOffline: boolean = false, networkType = NetworkType.TEST_NET): RepositoryFactory {
+    public static createRepositoryFactory(
+        url: string,
+        isOffline: boolean = false,
+        networkType = NetworkType.TEST_NET,
+        nodeWsUrl?: string,
+    ): RepositoryFactory {
         return isOffline
             ? new OfflineRepositoryFactory(networkType)
             : new RepositoryFactoryHttp(url, {
-                  websocketUrl: URLHelpers.httpToWsUrl(url) + '/ws',
+                  websocketUrl: nodeWsUrl || URLHelpers.httpToWsUrl(url) + '/ws',
                   websocketInjected: WebSocket,
               });
     }

--- a/src/views/forms/FormExtendNamespaceDurationTransaction/FormExtendNamespaceDurationTransactionTs.ts
+++ b/src/views/forms/FormExtendNamespaceDurationTransaction/FormExtendNamespaceDurationTransactionTs.ts
@@ -117,6 +117,6 @@ export class FormExtendNamespaceDurationTransactionTs extends FormNamespaceRegis
     }
 
     async mounted() {
-        this.$store.dispatch('network/REST_NETWORK_RENTAL_FEES');
+        await this.$store.dispatch('network/REST_NETWORK_RENTAL_FEES');
     }
 }

--- a/src/views/forms/FormNodeEdit/FormNodeEditTs.ts
+++ b/src/views/forms/FormNodeEdit/FormNodeEditTs.ts
@@ -100,6 +100,9 @@ export class FormNodeEditTs extends Vue {
             }
             this.formItems.networkType = NetworkType[networkModel.networkType];
             this.formItems.networkHash = networkModel.generationHash;
+        } catch (err) {
+            console.error(err);
+            return this.$store.dispatch('notification/ADD_ERROR', this.$t(NotificationType.INVALID_NODE));
         } finally {
             this.isGettingNodeInfo = false;
         }


### PR DESCRIPTION
Currently, when a node allows SSL/port:3001 and does not provide a stable connection for WebSockets subscription the wallet fails to login.

Proposed solution:
fallback for HTTP/port:3000 and retry the connection, in case it fails wallet should fall-back to a different node seeking a valid Websocets connection.