### PR TITLE
fix offline transactions issue

### DIFF
--- a/src/config/AppConfig.ts
+++ b/src/config/AppConfig.ts
@@ -35,7 +35,7 @@ export interface AppConfig {
         DECIMAL_SEPARATOR: string;
     };
     title: string;
-    marketServerUrl: string;
+    offlineNodeModelUrl: string;
 }
 
 const defaultAppConfig: AppConfig = {
@@ -59,9 +59,9 @@ const defaultAppConfig: AppConfig = {
         { value: 'ko-KR', label: '한국어' },
         { value: 'ru-RU', label: 'Русский' },
     ],
-    marketServerUrl: 'http://app.nemcn.io',
     articlesFeedUrl: 'https://symbol.github.io/symbol-rss-feeds/',
     repositoryDataUrl: 'https://api.github.com/repos/symbol/desktop-wallet/releases/latest',
+    offlineNodeModelUrl: 'https://localhost:3000',
 };
 const resolvedAppConfig: AppConfig = window['appConfig'] || defaultAppConfig;
 console.log('appConfig resolved!', resolvedAppConfig);

--- a/src/services/NodeService.ts
+++ b/src/services/NodeService.ts
@@ -19,7 +19,7 @@ import { ObservableHelpers } from '@/core/utils/ObservableHelpers';
 import { map, tap } from 'rxjs/operators';
 import { NodeModel } from '@/core/database/entities/NodeModel';
 import * as _ from 'lodash';
-import { networkConfig } from '@/config';
+import { appConfig, networkConfig } from '@/config';
 import { NodeModelStorage } from '@/core/database/storage/NodeModelStorage';
 import { ProfileModel } from '@/core/database/entities/ProfileModel';
 import fetch from 'node-fetch';
@@ -204,5 +204,12 @@ export class NodeService {
                 basePath: statisticsServiceUrl,
             }),
         );
+    }
+    /**
+     * Creates offline mock node model for offline transaction
+     * @param {networkType} NetworkType
+     */
+    public createOfflineNodeModel(networkType: NetworkType): NodeModel {
+        return this.createNodeModel(appConfig.offlineNodeModelUrl, networkType, 'offlineNodeMock', undefined, undefined, undefined);
     }
 }

--- a/src/store/Network.ts
+++ b/src/store/Network.ts
@@ -379,7 +379,14 @@ export default {
                         nodesList = nodesList.filter((n) => n.url !== currentProfile.selectedNodeUrlToConnect);
                     }
                 }
-
+                if (!nodesList.length && isOffline) {
+                    const knownNodes = nodeService.getKnownNodesOnly(currentProfile);
+                    if (!knownNodes.length) {
+                        nodesList.push(nodeService.createOfflineNodeModel(currentProfile.networkType));
+                    } else {
+                        nodesList = knownNodes;
+                    }
+                }
                 // try other nodes randomly if not found yet
                 while (!nodeFound && nodesList.length) {
                     const inx = Math.floor(Math.random() * nodesList.length);


### PR DESCRIPTION
Offline Transaction page need a node url to be able to mock transaction data

Old Behavior: - Wallet is not able to fetch nodes from statistics service and end up with one node in storage which get filtered and emptied before mocking the data.

Introduced solution: 
- Query the storage to get urls to which that profile was previously connected and use them to mock the needed data.
- In case the wallet is never connected to the internet use a fake node to mock repositories and display UI correctly.