### PR TITLE
feat: add the scam alert link to docs in the harvesting view

### DIFF
--- a/src/views/forms/FormPersistentDelegationRequestTransaction/FormPersistentDelegationRequestTransaction.vue
+++ b/src/views/forms/FormPersistentDelegationRequestTransaction/FormPersistentDelegationRequestTransaction.vue
@@ -14,6 +14,7 @@
                         <div class="info-text">
                             <p v-if="harvestingStatus === 'INACTIVE'">
                                 {{ $t('harvesting_delegated_description') }}
+                                <a :href="symbolDocsScamAlertUrl" target="_blank"> {{ $t('link_docs_scam') }} </a>
                             </p>
                             <p v-if="harvestingStatus === 'INACTIVE'">
                                 {{ $t('harvesting_node_selection') }}

--- a/src/views/forms/FormPersistentDelegationRequestTransaction/FormPersistentDelegationRequestTransactionTs.ts
+++ b/src/views/forms/FormPersistentDelegationRequestTransaction/FormPersistentDelegationRequestTransactionTs.ts
@@ -132,12 +132,18 @@ export enum PublicKeyTitle {
             currentAccount: 'account/currentAccount',
             feesConfig: 'network/feesConfig',
             accountsInfo: 'account/accountsInfo',
+            symbolDocsScamAlertUrl: 'app/symbolDocsScamAlertUrl',
         }),
     },
 })
 export class FormPersistentDelegationRequestTransactionTs extends FormTransactionBase {
     @Prop({ default: null }) signerAddress: string;
     //@Prop({ default: true }) withLink: boolean;
+
+    /**
+     * Link to the Common Hacks and Scams docs page
+     */
+    public symbolDocsScamAlertUrl: string;
 
     /**
      * Formatters helpers

--- a/src/views/forms/FormPersistentDelegationRequestTransaction/FormPersistentDelegationRequestTransactionTs.ts
+++ b/src/views/forms/FormPersistentDelegationRequestTransaction/FormPersistentDelegationRequestTransactionTs.ts
@@ -87,7 +87,7 @@ import ModalConfirm from '@/views/modals/ModalConfirm/ModalConfirm.vue';
 // @ts-ignore
 import MaxFeeSelector from '@/components/MaxFeeSelector/MaxFeeSelector.vue';
 import { NodeService } from '@/services/NodeService';
-import { feesConfig as defaultFeesConfig } from '@/config';
+import { feesConfig as defaultFeesConfig, networkConfig } from '@/config';
 
 export enum HarvestingAction {
     START = 1,
@@ -188,7 +188,7 @@ export class FormPersistentDelegationRequestTransactionTs extends FormTransactio
     public activeIndex = 0;
 
     public get allNodeListUrl() {
-        return this.$store.getters['app/explorerUrl'] + 'nodes';
+        return networkConfig[this.networkType].explorerUrl.replace(/\/+$/, '') + '/nodes';
     }
 
     public get activePanel() {


### PR DESCRIPTION
### What was the issue?
- Users must be warned about the risks of fraud while activating harvesting.
### What's the fix?
- Added the [Learn more about common hacks and scams](https://docs.symbol.dev/guides/account/scams-and-security.html) link to the harvesting view.
- Fixed broken explorer URL