### PR TITLE
add one-click harvesting configuration #1820

### DIFF
--- a/src/store/Harvesting.ts
+++ b/src/store/Harvesting.ts
@@ -226,7 +226,7 @@ export default {
                     ? pollingTrials === 20 || currentSignerHarvestingModel?.delegatedHarvestingRequestFailed
                         ? HarvestingStatus.FAILED
                         : HarvestingStatus.INPROGRESS_ACTIVATION
-                    : HarvestingStatus.KEYS_LINKED;
+                    : HarvestingStatus.INACTIVE;
                 if (status === HarvestingStatus.ACTIVE && node && node[1]) {
                     // @ts-ignore
                     dispatch('UPDATE_ACCOUNT_SELECTED_HARVESTING_NODE', {

--- a/src/views/forms/FormPersistentDelegationRequestTransaction/FormPersistentDelegationRequestTransaction.vue
+++ b/src/views/forms/FormPersistentDelegationRequestTransaction/FormPersistentDelegationRequestTransaction.vue
@@ -2,7 +2,7 @@
     <div class="form-persistent-delegation-request">
         <NavigationLinks
             :direction="'horizontal'"
-            :items="['delegated_harvesting', 'key_links']"
+            :items="['delegated_harvesting']"
             :current-item-index="activePanel"
             translation-prefix="tab_harvesting_"
             @selected="(i) => (activePanel = i)"

--- a/src/views/forms/FormPersistentDelegationRequestTransaction/FormPersistentDelegationRequestTransaction.vue
+++ b/src/views/forms/FormPersistentDelegationRequestTransaction/FormPersistentDelegationRequestTransaction.vue
@@ -2,7 +2,7 @@
     <div class="form-persistent-delegation-request">
         <NavigationLinks
             :direction="'horizontal'"
-            :items="['delegated_harvesting']"
+            :items="['delegated_harvesting', 'key_links']"
             :current-item-index="activePanel"
             translation-prefix="tab_harvesting_"
             @selected="(i) => (activePanel = i)"


### PR DESCRIPTION
### What the current behaviour is

- Currently, harvesting in mobile and desktop wallets is working in two steps.  #1820 


### Why this is an issue

- These two transactions can be combined into one aggregate transaction

### What's the fix

1. Create Account Links (Remote, VRF, Node).
2. Send a persistent delegated message to Node.

These two transactions are combined into one and sent as an aggregate transaction.