### PR TITLE
[wallet/desktop] feat: added nyc intg, enabled ci coverage check

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -24,3 +24,4 @@ template.config.js
 .env
 keys-whitelist.json
 keys-finance.json
+.nyc_output

--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -6,4 +6,7 @@ defaultCiPipeline {
 
 	publisher = 'docker'
 	dockerImageName = 'symbolplatform/symbol-desktop-wallet'
+
+	codeCoverageTool = 'nyc'
+	minimumCodeCoverage = 27
 }

--- a/README.md
+++ b/README.md
@@ -1,7 +1,17 @@
 # Symbol Desktop Wallet
 
-[![Build Status](https://travis-ci.com/symbol/desktop-wallet.svg?branch=main)](https://travis-ci.com/symbol/desktop-wallet)
+[![build][wallet-desktop-build]][wallet-desktop-job]
+[![lint][wallet-desktop-lint]][wallet-desktop-job]
+[![test][wallet-desktop-test]][wallet-desktop-job]
+[![][wallet-desktop-cov]][wallet-desktop-cov-link]
 [![License](https://img.shields.io/badge/License-Apache%202.0-blue.svg)](https://opensource.org/licenses/Apache-2.0)
+
+[wallet-desktop-job]: https://jenkins.symboldev.com/blue/organizations/jenkins/Symbol%2FWallets%2Fdesktop-wallet/activity/?branch=dev
+[wallet-desktop-build]: https://jenkins.symboldev.com/buildStatus/icon?job=Symbol%2FWallets%2Fdesktop-wallet%2Fdev
+[wallet-desktop-lint]: https://jenkins.symboldev.com/buildStatus/icon?job=Symbol%2FWallets%2Fdesktop-wallet%2Fdev&config=wallet-desktop-lint
+[wallet-desktop-test]: https://jenkins.symboldev.com/buildStatus/icon?job=Symbol%2FWallets%2Fdesktop-wallet%2Fdev&config=wallet-desktop-test
+[wallet-desktop-cov]: https://codecov.io/gh/symbol/desktop-wallet/branch/dev/graph/badge.svg?token=SSYYBMK0M7&flag=wallet-desktop
+[wallet-desktop-cov-link]: https://codecov.io/gh/symbol/desktop-wallet/tree/dev/
 
 Cross-platform client for Symbol to manage accounts, mosaics, namespaces, and issue transactions.
 
@@ -17,7 +27,7 @@ Symbol Desktop Wallet is available for Mac, Windows, and as a web application.
 
 ## Building instructions
 
-Symbol CLI require **Node.js 10 or 12 LTS** to execute.
+Symbol CLI require **Node.js 16 LTS** to execute.
 
 1. Clone the project.
 
@@ -28,13 +38,13 @@ git clone https://github.com/symbol/desktop-wallet.git
 2. Install the dependencies.
 ```
 cd symbol-desktop-wallet
-npm install 
+npm install
 ```
 
 3. Start the development server.
 
 ```
-npm run dev 
+npm run dev
 ```
 
 4. Visit http://localhost:8080/#/ in your browser.
@@ -44,12 +54,12 @@ npm run dev
 Use the following available resources to get help:
 
 - [Symbol Documentation][docs]
-- Join the community [discord group][discord], [slack group (#sig-client)][slack] 
+- Join the community [discord group][discord], [slack group (#sig-client)][slack]
 - If you found a bug, [open a new issue][issues]
 
 ## Contributing
 
-Contributions are welcome and appreciated. 
+Contributions are welcome and appreciated.
 Check [CONTRIBUTING](CONTRIBUTING.md) for information on how to contribute.
 
 ## License

--- a/package-lock.json
+++ b/package-lock.json
@@ -96,6 +96,7 @@
                 "node-pre-gyp": "^0.13.0",
                 "npm-build-zip": "^1.0.2",
                 "nth-check": ">=2.0.1",
+                "nyc": "^15.1.0",
                 "postcss-import": "^12.0.1",
                 "postcss-pxtorem": "^4.0.1",
                 "prettier": "2.0.5",
@@ -6389,6 +6390,19 @@
                 "node": ">= 6.0.0"
             }
         },
+        "node_modules/aggregate-error": {
+            "version": "3.1.0",
+            "resolved": "https://registry.npmjs.org/aggregate-error/-/aggregate-error-3.1.0.tgz",
+            "integrity": "sha512-4I7Td01quW/RpocfNayFdFVk1qSuoh0E7JrbRJ16nH01HhKFQ88INq9Sd+nd72zqRySlr9BmDA8xlEJ6vJMrYA==",
+            "dev": true,
+            "dependencies": {
+                "clean-stack": "^2.0.0",
+                "indent-string": "^4.0.0"
+            },
+            "engines": {
+                "node": ">=8"
+            }
+        },
         "node_modules/ajv": {
             "version": "6.12.6",
             "resolved": "https://registry.npmjs.org/ajv/-/ajv-6.12.6.tgz",
@@ -6623,6 +6637,18 @@
             "integrity": "sha512-3wdGidZyq5PB084XLES5TpOSRA3wjXAlIWMhum2kRcv/41Sn2emQ0dycQW4uZXLejwKvg6EsvbdlVL+FYEct7A==",
             "dev": true
         },
+        "node_modules/append-transform": {
+            "version": "2.0.0",
+            "resolved": "https://registry.npmjs.org/append-transform/-/append-transform-2.0.0.tgz",
+            "integrity": "sha512-7yeyCEurROLQJFv5Xj4lEGTy0borxepjFv1g22oAdqFu//SrAlDl1O1Nxx15SH1RoliUml6p8dwJW9jvZughhg==",
+            "dev": true,
+            "dependencies": {
+                "default-require-extensions": "^3.0.0"
+            },
+            "engines": {
+                "node": ">=8"
+            }
+        },
         "node_modules/aproba": {
             "version": "1.2.0",
             "resolved": "https://registry.npmjs.org/aproba/-/aproba-1.2.0.tgz",
@@ -6714,6 +6740,12 @@
             "dependencies": {
                 "lodash": "^4.17.14"
             }
+        },
+        "node_modules/archy": {
+            "version": "1.0.0",
+            "resolved": "https://registry.npmjs.org/archy/-/archy-1.0.0.tgz",
+            "integrity": "sha512-Xg+9RwCg/0p32teKdGMPTPnVXKD0w3DfHnFTficozsAgsvq2XenPJq/MYpzzQ/v8zrOyJn6Ds39VA4JIDwFfqw==",
+            "dev": true
         },
         "node_modules/are-we-there-yet": {
             "version": "1.1.7",
@@ -8980,6 +9012,21 @@
                 "node": ">=8"
             }
         },
+        "node_modules/caching-transform": {
+            "version": "4.0.0",
+            "resolved": "https://registry.npmjs.org/caching-transform/-/caching-transform-4.0.0.tgz",
+            "integrity": "sha512-kpqOvwXnjjN44D89K5ccQC+RUrsy7jB/XLlRrx0D7/2HNcTPqzsb6XgYoErwko6QsV184CA2YgS1fxDiiDZMWA==",
+            "dev": true,
+            "dependencies": {
+                "hasha": "^5.0.0",
+                "make-dir": "^3.0.0",
+                "package-hash": "^4.0.0",
+                "write-file-atomic": "^3.0.0"
+            },
+            "engines": {
+                "node": ">=8"
+            }
+        },
         "node_modules/call-bind": {
             "version": "1.0.2",
             "resolved": "https://registry.npmjs.org/call-bind/-/call-bind-1.0.2.tgz",
@@ -9323,6 +9370,15 @@
             "dev": true,
             "engines": {
                 "node": ">=0.10.0"
+            }
+        },
+        "node_modules/clean-stack": {
+            "version": "2.2.0",
+            "resolved": "https://registry.npmjs.org/clean-stack/-/clean-stack-2.2.0.tgz",
+            "integrity": "sha512-4diC9HaTE+KRAMWhDhrGOECgWZxoevMc5TlkObMqNSsVU62PYzXZ/SMTjzyGAFF1YusgxGcSWTEXBhp0CPwQ1A==",
+            "dev": true,
+            "engines": {
+                "node": ">=6"
             }
         },
         "node_modules/cli-boxes": {
@@ -10928,6 +10984,18 @@
             },
             "engines": {
                 "node": ">= 8"
+            }
+        },
+        "node_modules/default-require-extensions": {
+            "version": "3.0.0",
+            "resolved": "https://registry.npmjs.org/default-require-extensions/-/default-require-extensions-3.0.0.tgz",
+            "integrity": "sha512-ek6DpXq/SCpvjhpFsLFRVtIxJCRw6fUR42lYMVZuUMK7n8eMz4Uh5clckdBjEpLhn/gEBZo7hDJnJcwdKLKQjg==",
+            "dev": true,
+            "dependencies": {
+                "strip-bom": "^4.0.0"
+            },
+            "engines": {
+                "node": ">=8"
             }
         },
         "node_modules/defaults": {
@@ -12703,8 +12771,7 @@
             "version": "4.1.1",
             "resolved": "https://registry.npmjs.org/es6-error/-/es6-error-4.1.1.tgz",
             "integrity": "sha512-Um/+FxMr9CISWh0bi5Zv0iOD+4cFh5qLeks1qhAopKVAJw3drgKbKySikp7wGhDL0HPeaja0P5ULZrxLkniUVg==",
-            "dev": true,
-            "optional": true
+            "dev": true
         },
         "node_modules/escalade": {
             "version": "3.1.1",
@@ -14135,6 +14202,78 @@
                 "node": ">=0.10.0"
             }
         },
+        "node_modules/foreground-child": {
+            "version": "2.0.0",
+            "resolved": "https://registry.npmjs.org/foreground-child/-/foreground-child-2.0.0.tgz",
+            "integrity": "sha512-dCIq9FpEcyQyXKCkyzmlPTFNgrCzPudOe+mhvJU5zAtlBnGVy2yKxtfsxK2tQBThwq225jcvBjpw1Gr40uzZCA==",
+            "dev": true,
+            "dependencies": {
+                "cross-spawn": "^7.0.0",
+                "signal-exit": "^3.0.2"
+            },
+            "engines": {
+                "node": ">=8.0.0"
+            }
+        },
+        "node_modules/foreground-child/node_modules/cross-spawn": {
+            "version": "7.0.3",
+            "resolved": "https://registry.npmjs.org/cross-spawn/-/cross-spawn-7.0.3.tgz",
+            "integrity": "sha512-iRDPJKUPVEND7dHPO8rkbOnPpyDygcDFtWjpeWNCgy8WP2rXcxXL8TskReQl6OrB2G7+UJrags1q15Fudc7G6w==",
+            "dev": true,
+            "dependencies": {
+                "path-key": "^3.1.0",
+                "shebang-command": "^2.0.0",
+                "which": "^2.0.1"
+            },
+            "engines": {
+                "node": ">= 8"
+            }
+        },
+        "node_modules/foreground-child/node_modules/path-key": {
+            "version": "3.1.1",
+            "resolved": "https://registry.npmjs.org/path-key/-/path-key-3.1.1.tgz",
+            "integrity": "sha512-ojmeN0qd+y0jszEtoY48r0Peq5dwMEkIlCOu6Q5f41lfkswXuKtYrhgoTpLnyIcHm24Uhqx+5Tqm2InSwLhE6Q==",
+            "dev": true,
+            "engines": {
+                "node": ">=8"
+            }
+        },
+        "node_modules/foreground-child/node_modules/shebang-command": {
+            "version": "2.0.0",
+            "resolved": "https://registry.npmjs.org/shebang-command/-/shebang-command-2.0.0.tgz",
+            "integrity": "sha512-kHxr2zZpYtdmrN1qDjrrX/Z1rR1kG8Dx+gkpK1G4eXmvXswmcE1hTWBWYUzlraYw1/yZp6YuDY77YtvbN0dmDA==",
+            "dev": true,
+            "dependencies": {
+                "shebang-regex": "^3.0.0"
+            },
+            "engines": {
+                "node": ">=8"
+            }
+        },
+        "node_modules/foreground-child/node_modules/shebang-regex": {
+            "version": "3.0.0",
+            "resolved": "https://registry.npmjs.org/shebang-regex/-/shebang-regex-3.0.0.tgz",
+            "integrity": "sha512-7++dFhtcx3353uBaq8DDR4NuxBetBzC7ZQOhmTQInHEd6bSrXdiEyzCvG07Z44UYdLShWUyXt5M/yhz8ekcb1A==",
+            "dev": true,
+            "engines": {
+                "node": ">=8"
+            }
+        },
+        "node_modules/foreground-child/node_modules/which": {
+            "version": "2.0.2",
+            "resolved": "https://registry.npmjs.org/which/-/which-2.0.2.tgz",
+            "integrity": "sha512-BLI3Tl1TW3Pvl70l3yq3Y64i+awpwXqsGBYWkkqMtnbXgrMD+yj7rhW0kuEDxzJaYXGjEW5ogapKNMEKNMjibA==",
+            "dev": true,
+            "dependencies": {
+                "isexe": "^2.0.0"
+            },
+            "bin": {
+                "node-which": "bin/node-which"
+            },
+            "engines": {
+                "node": ">= 8"
+            }
+        },
         "node_modules/forever-agent": {
             "version": "0.6.1",
             "resolved": "https://registry.npmjs.org/forever-agent/-/forever-agent-0.6.1.tgz",
@@ -14622,6 +14761,26 @@
                 "inherits": "^2.0.1",
                 "readable-stream": "^2.0.0"
             }
+        },
+        "node_modules/fromentries": {
+            "version": "1.3.2",
+            "resolved": "https://registry.npmjs.org/fromentries/-/fromentries-1.3.2.tgz",
+            "integrity": "sha512-cHEpEQHUg0f8XdtZCc2ZAhrHzKzT0MrFUTcvx+hfxYu7rGMDc5SKoXFh+n4YigxsHXRzc6OrCshdR1bWH6HHyg==",
+            "dev": true,
+            "funding": [
+                {
+                    "type": "github",
+                    "url": "https://github.com/sponsors/feross"
+                },
+                {
+                    "type": "patreon",
+                    "url": "https://www.patreon.com/feross"
+                },
+                {
+                    "type": "consulting",
+                    "url": "https://feross.org/support"
+                }
+            ]
         },
         "node_modules/fs-constants": {
             "version": "1.0.0",
@@ -15425,6 +15584,43 @@
                 "minimalistic-assert": "^1.0.1"
             }
         },
+        "node_modules/hasha": {
+            "version": "5.2.2",
+            "resolved": "https://registry.npmjs.org/hasha/-/hasha-5.2.2.tgz",
+            "integrity": "sha512-Hrp5vIK/xr5SkeN2onO32H0MgNZ0f17HRNH39WfL0SYUNOTZ5Lz1TJ8Pajo/87dYGEFlLMm7mIc/k/s6Bvz9HQ==",
+            "dev": true,
+            "dependencies": {
+                "is-stream": "^2.0.0",
+                "type-fest": "^0.8.0"
+            },
+            "engines": {
+                "node": ">=8"
+            },
+            "funding": {
+                "url": "https://github.com/sponsors/sindresorhus"
+            }
+        },
+        "node_modules/hasha/node_modules/is-stream": {
+            "version": "2.0.1",
+            "resolved": "https://registry.npmjs.org/is-stream/-/is-stream-2.0.1.tgz",
+            "integrity": "sha512-hFoiJiTl63nn+kstHGBtewWSKnQLpyb155KHheA1l39uvtO9nWIop1p3udqPcUd/xbF1VLMO4n7OI6p7RbngDg==",
+            "dev": true,
+            "engines": {
+                "node": ">=8"
+            },
+            "funding": {
+                "url": "https://github.com/sponsors/sindresorhus"
+            }
+        },
+        "node_modules/hasha/node_modules/type-fest": {
+            "version": "0.8.1",
+            "resolved": "https://registry.npmjs.org/type-fest/-/type-fest-0.8.1.tgz",
+            "integrity": "sha512-4dbzIzqvjtgiM5rw1k5rEHtBANKmdudhGyBEajN01fEyhaAIhsoKNy6y7+IN93IfpFtwY9iqi7kD+xwKhQsNJA==",
+            "dev": true,
+            "engines": {
+                "node": ">=8"
+            }
+        },
         "node_modules/he": {
             "version": "1.2.0",
             "resolved": "https://registry.npmjs.org/he/-/he-1.2.0.tgz",
@@ -15969,6 +16165,15 @@
             "integrity": "sha1-khi5srkoojixPcT7a21XbyMUU+o=",
             "engines": {
                 "node": ">=0.8.19"
+            }
+        },
+        "node_modules/indent-string": {
+            "version": "4.0.0",
+            "resolved": "https://registry.npmjs.org/indent-string/-/indent-string-4.0.0.tgz",
+            "integrity": "sha512-EdDDZu4A2OyIK7Lr/2zG+w5jmbuk1DVBnEwREQvBzspBJkCEbRa8GxU1lghYcaGJCnRWibjDXlq779X1/y5xwg==",
+            "dev": true,
+            "engines": {
+                "node": ">=8"
             }
         },
         "node_modules/indexes-of": {
@@ -16783,6 +16988,18 @@
                 "node": ">=8"
             }
         },
+        "node_modules/istanbul-lib-hook": {
+            "version": "3.0.0",
+            "resolved": "https://registry.npmjs.org/istanbul-lib-hook/-/istanbul-lib-hook-3.0.0.tgz",
+            "integrity": "sha512-Pt/uge1Q9s+5VAZ+pCo16TYMWPBIl+oaNIjgLQxcX0itS6ueeaA+pEfThZpH8WxhFgCiEb8sAJY6MdUKgiIWaQ==",
+            "dev": true,
+            "dependencies": {
+                "append-transform": "^2.0.0"
+            },
+            "engines": {
+                "node": ">=8"
+            }
+        },
         "node_modules/istanbul-lib-instrument": {
             "version": "5.1.0",
             "resolved": "https://registry.npmjs.org/istanbul-lib-instrument/-/istanbul-lib-instrument-5.1.0.tgz",
@@ -16797,6 +17014,94 @@
             },
             "engines": {
                 "node": ">=8"
+            }
+        },
+        "node_modules/istanbul-lib-processinfo": {
+            "version": "2.0.3",
+            "resolved": "https://registry.npmjs.org/istanbul-lib-processinfo/-/istanbul-lib-processinfo-2.0.3.tgz",
+            "integrity": "sha512-NkwHbo3E00oybX6NGJi6ar0B29vxyvNwoC7eJ4G4Yq28UfY758Hgn/heV8VRFhevPED4LXfFz0DQ8z/0kw9zMg==",
+            "dev": true,
+            "dependencies": {
+                "archy": "^1.0.0",
+                "cross-spawn": "^7.0.3",
+                "istanbul-lib-coverage": "^3.2.0",
+                "p-map": "^3.0.0",
+                "rimraf": "^3.0.0",
+                "uuid": "^8.3.2"
+            },
+            "engines": {
+                "node": ">=8"
+            }
+        },
+        "node_modules/istanbul-lib-processinfo/node_modules/cross-spawn": {
+            "version": "7.0.3",
+            "resolved": "https://registry.npmjs.org/cross-spawn/-/cross-spawn-7.0.3.tgz",
+            "integrity": "sha512-iRDPJKUPVEND7dHPO8rkbOnPpyDygcDFtWjpeWNCgy8WP2rXcxXL8TskReQl6OrB2G7+UJrags1q15Fudc7G6w==",
+            "dev": true,
+            "dependencies": {
+                "path-key": "^3.1.0",
+                "shebang-command": "^2.0.0",
+                "which": "^2.0.1"
+            },
+            "engines": {
+                "node": ">= 8"
+            }
+        },
+        "node_modules/istanbul-lib-processinfo/node_modules/p-map": {
+            "version": "3.0.0",
+            "resolved": "https://registry.npmjs.org/p-map/-/p-map-3.0.0.tgz",
+            "integrity": "sha512-d3qXVTF/s+W+CdJ5A29wywV2n8CQQYahlgz2bFiA+4eVNJbHJodPZ+/gXwPGh0bOqA+j8S+6+ckmvLGPk1QpxQ==",
+            "dev": true,
+            "dependencies": {
+                "aggregate-error": "^3.0.0"
+            },
+            "engines": {
+                "node": ">=8"
+            }
+        },
+        "node_modules/istanbul-lib-processinfo/node_modules/path-key": {
+            "version": "3.1.1",
+            "resolved": "https://registry.npmjs.org/path-key/-/path-key-3.1.1.tgz",
+            "integrity": "sha512-ojmeN0qd+y0jszEtoY48r0Peq5dwMEkIlCOu6Q5f41lfkswXuKtYrhgoTpLnyIcHm24Uhqx+5Tqm2InSwLhE6Q==",
+            "dev": true,
+            "engines": {
+                "node": ">=8"
+            }
+        },
+        "node_modules/istanbul-lib-processinfo/node_modules/shebang-command": {
+            "version": "2.0.0",
+            "resolved": "https://registry.npmjs.org/shebang-command/-/shebang-command-2.0.0.tgz",
+            "integrity": "sha512-kHxr2zZpYtdmrN1qDjrrX/Z1rR1kG8Dx+gkpK1G4eXmvXswmcE1hTWBWYUzlraYw1/yZp6YuDY77YtvbN0dmDA==",
+            "dev": true,
+            "dependencies": {
+                "shebang-regex": "^3.0.0"
+            },
+            "engines": {
+                "node": ">=8"
+            }
+        },
+        "node_modules/istanbul-lib-processinfo/node_modules/shebang-regex": {
+            "version": "3.0.0",
+            "resolved": "https://registry.npmjs.org/shebang-regex/-/shebang-regex-3.0.0.tgz",
+            "integrity": "sha512-7++dFhtcx3353uBaq8DDR4NuxBetBzC7ZQOhmTQInHEd6bSrXdiEyzCvG07Z44UYdLShWUyXt5M/yhz8ekcb1A==",
+            "dev": true,
+            "engines": {
+                "node": ">=8"
+            }
+        },
+        "node_modules/istanbul-lib-processinfo/node_modules/which": {
+            "version": "2.0.2",
+            "resolved": "https://registry.npmjs.org/which/-/which-2.0.2.tgz",
+            "integrity": "sha512-BLI3Tl1TW3Pvl70l3yq3Y64i+awpwXqsGBYWkkqMtnbXgrMD+yj7rhW0kuEDxzJaYXGjEW5ogapKNMEKNMjibA==",
+            "dev": true,
+            "dependencies": {
+                "isexe": "^2.0.0"
+            },
+            "bin": {
+                "node-which": "bin/node-which"
+            },
+            "engines": {
+                "node": ">= 8"
             }
         },
         "node_modules/istanbul-lib-report": {
@@ -21268,6 +21573,12 @@
             "integrity": "sha512-3j8wdDzYuWO3lM3Reg03MuQR957t287Rpcxp1njpEa8oDrikb+FwGdW3n+FELh/A6qib6yPit0j/pv9G/yeAqA==",
             "dev": true
         },
+        "node_modules/lodash.flattendeep": {
+            "version": "4.4.0",
+            "resolved": "https://registry.npmjs.org/lodash.flattendeep/-/lodash.flattendeep-4.4.0.tgz",
+            "integrity": "sha512-uHaJFihxmJcEX3kT4I23ABqKKalJ/zDrDg0lsFtc1h+3uw49SIJ5beyhx5ExVRti3AvKoOJngIj7xz3oylPdWQ==",
+            "dev": true
+        },
         "node_modules/lodash.get": {
             "version": "4.4.2",
             "resolved": "https://registry.npmjs.org/lodash.get/-/lodash.get-4.4.2.tgz",
@@ -22641,6 +22952,18 @@
                 "node": ">=4.5"
             }
         },
+        "node_modules/node-preload": {
+            "version": "0.2.1",
+            "resolved": "https://registry.npmjs.org/node-preload/-/node-preload-0.2.1.tgz",
+            "integrity": "sha512-RM5oyBy45cLEoHqCeh+MNuFAxO0vTFBLskvQbOKnEE7YTTSN4tbN8QWDIPQ6L+WvKsB/qLEGpYe2ZZ9d4W9OIQ==",
+            "dev": true,
+            "dependencies": {
+                "process-on-spawn": "^1.0.0"
+            },
+            "engines": {
+                "node": ">=8"
+            }
+        },
         "node_modules/node-releases": {
             "version": "2.0.1",
             "resolved": "https://registry.npmjs.org/node-releases/-/node-releases-2.0.1.tgz",
@@ -23030,6 +23353,127 @@
             "resolved": "https://registry.npmjs.org/nwsapi/-/nwsapi-2.2.0.tgz",
             "integrity": "sha512-h2AatdwYH+JHiZpv7pt/gSX1XoRGb7L/qSIeuqA6GwYoF9w1vP1cw42TO0aI2pNyshRK5893hNSl+1//vHK7hQ==",
             "dev": true
+        },
+        "node_modules/nyc": {
+            "version": "15.1.0",
+            "resolved": "https://registry.npmjs.org/nyc/-/nyc-15.1.0.tgz",
+            "integrity": "sha512-jMW04n9SxKdKi1ZMGhvUTHBN0EICCRkHemEoE5jm6mTYcqcdas0ATzgUgejlQUHMvpnOZqGB5Xxsv9KxJW1j8A==",
+            "dev": true,
+            "dependencies": {
+                "@istanbuljs/load-nyc-config": "^1.0.0",
+                "@istanbuljs/schema": "^0.1.2",
+                "caching-transform": "^4.0.0",
+                "convert-source-map": "^1.7.0",
+                "decamelize": "^1.2.0",
+                "find-cache-dir": "^3.2.0",
+                "find-up": "^4.1.0",
+                "foreground-child": "^2.0.0",
+                "get-package-type": "^0.1.0",
+                "glob": "^7.1.6",
+                "istanbul-lib-coverage": "^3.0.0",
+                "istanbul-lib-hook": "^3.0.0",
+                "istanbul-lib-instrument": "^4.0.0",
+                "istanbul-lib-processinfo": "^2.0.2",
+                "istanbul-lib-report": "^3.0.0",
+                "istanbul-lib-source-maps": "^4.0.0",
+                "istanbul-reports": "^3.0.2",
+                "make-dir": "^3.0.0",
+                "node-preload": "^0.2.1",
+                "p-map": "^3.0.0",
+                "process-on-spawn": "^1.0.0",
+                "resolve-from": "^5.0.0",
+                "rimraf": "^3.0.0",
+                "signal-exit": "^3.0.2",
+                "spawn-wrap": "^2.0.0",
+                "test-exclude": "^6.0.0",
+                "yargs": "^15.0.2"
+            },
+            "bin": {
+                "nyc": "bin/nyc.js"
+            },
+            "engines": {
+                "node": ">=8.9"
+            }
+        },
+        "node_modules/nyc/node_modules/camelcase": {
+            "version": "5.3.1",
+            "resolved": "https://registry.npmjs.org/camelcase/-/camelcase-5.3.1.tgz",
+            "integrity": "sha512-L28STB170nwWS63UjtlEOE3dldQApaJXZkOI1uMFfzf3rRuPegHaHesyee+YxQ+W6SvRDQV6UrdOdRiR153wJg==",
+            "dev": true,
+            "engines": {
+                "node": ">=6"
+            }
+        },
+        "node_modules/nyc/node_modules/decamelize": {
+            "version": "1.2.0",
+            "resolved": "https://registry.npmjs.org/decamelize/-/decamelize-1.2.0.tgz",
+            "integrity": "sha512-z2S+W9X73hAUUki+N+9Za2lBlun89zigOyGrsax+KUQ6wKW4ZoWpEYBkGhQjwAjjDCkWxhY0VKEhk8wzY7F5cA==",
+            "dev": true,
+            "engines": {
+                "node": ">=0.10.0"
+            }
+        },
+        "node_modules/nyc/node_modules/istanbul-lib-instrument": {
+            "version": "4.0.3",
+            "resolved": "https://registry.npmjs.org/istanbul-lib-instrument/-/istanbul-lib-instrument-4.0.3.tgz",
+            "integrity": "sha512-BXgQl9kf4WTCPCCpmFGoJkz/+uhvm7h7PFKUYxh7qarQd3ER33vHG//qaE8eN25l07YqZPpHXU9I09l/RD5aGQ==",
+            "dev": true,
+            "dependencies": {
+                "@babel/core": "^7.7.5",
+                "@istanbuljs/schema": "^0.1.2",
+                "istanbul-lib-coverage": "^3.0.0",
+                "semver": "^6.3.0"
+            },
+            "engines": {
+                "node": ">=8"
+            }
+        },
+        "node_modules/nyc/node_modules/p-map": {
+            "version": "3.0.0",
+            "resolved": "https://registry.npmjs.org/p-map/-/p-map-3.0.0.tgz",
+            "integrity": "sha512-d3qXVTF/s+W+CdJ5A29wywV2n8CQQYahlgz2bFiA+4eVNJbHJodPZ+/gXwPGh0bOqA+j8S+6+ckmvLGPk1QpxQ==",
+            "dev": true,
+            "dependencies": {
+                "aggregate-error": "^3.0.0"
+            },
+            "engines": {
+                "node": ">=8"
+            }
+        },
+        "node_modules/nyc/node_modules/yargs": {
+            "version": "15.4.1",
+            "resolved": "https://registry.npmjs.org/yargs/-/yargs-15.4.1.tgz",
+            "integrity": "sha512-aePbxDmcYW++PaqBsJ+HYUFwCdv4LVvdnhBy78E57PIor8/OVvhMrADFFEDh8DHDFRv/O9i3lPhsENjO7QX0+A==",
+            "dev": true,
+            "dependencies": {
+                "cliui": "^6.0.0",
+                "decamelize": "^1.2.0",
+                "find-up": "^4.1.0",
+                "get-caller-file": "^2.0.1",
+                "require-directory": "^2.1.1",
+                "require-main-filename": "^2.0.0",
+                "set-blocking": "^2.0.0",
+                "string-width": "^4.2.0",
+                "which-module": "^2.0.0",
+                "y18n": "^4.0.0",
+                "yargs-parser": "^18.1.2"
+            },
+            "engines": {
+                "node": ">=8"
+            }
+        },
+        "node_modules/nyc/node_modules/yargs-parser": {
+            "version": "18.1.3",
+            "resolved": "https://registry.npmjs.org/yargs-parser/-/yargs-parser-18.1.3.tgz",
+            "integrity": "sha512-o50j0JeToy/4K6OZcaQmW6lyXXKhq7csREXcDwk2omFPJEwUNOVtJKvmDr9EI1fAJZUyZcRF7kxGBWmRXudrCQ==",
+            "dev": true,
+            "dependencies": {
+                "camelcase": "^5.0.0",
+                "decamelize": "^1.2.0"
+            },
+            "engines": {
+                "node": ">=6"
+            }
         },
         "node_modules/oauth-sign": {
             "version": "0.9.0",
@@ -23558,6 +24002,21 @@
             "integrity": "sha512-R4nPAVTAU0B9D35/Gk3uJf/7XYbQcyohSKdvAxIRSNghFl4e71hVoGnBNQz9cWaXxO2I10KTC+3jMdvvoKw6dQ==",
             "engines": {
                 "node": ">=6"
+            }
+        },
+        "node_modules/package-hash": {
+            "version": "4.0.0",
+            "resolved": "https://registry.npmjs.org/package-hash/-/package-hash-4.0.0.tgz",
+            "integrity": "sha512-whdkPIooSu/bASggZ96BWVvZTRMOFxnyUG5PnTSGKoJE2gd5mbVNmR2Nj20QFzxYYgAXpoqC+AiXzl+UMRh7zQ==",
+            "dev": true,
+            "dependencies": {
+                "graceful-fs": "^4.1.15",
+                "hasha": "^5.0.0",
+                "lodash.flattendeep": "^4.4.0",
+                "release-zalgo": "^1.0.0"
+            },
+            "engines": {
+                "node": ">=8"
             }
         },
         "node_modules/package-json": {
@@ -24913,6 +25372,18 @@
             "resolved": "https://registry.npmjs.org/process-nextick-args/-/process-nextick-args-2.0.1.tgz",
             "integrity": "sha512-3ouUOpQhtgrbOa17J7+uxOTpITYWaGP7/AhoR3+A+/1e9skrzelGi/dXzEYyvbxubEF6Wn2ypscTKiKJFFn1ag=="
         },
+        "node_modules/process-on-spawn": {
+            "version": "1.0.0",
+            "resolved": "https://registry.npmjs.org/process-on-spawn/-/process-on-spawn-1.0.0.tgz",
+            "integrity": "sha512-1WsPDsUSMmZH5LeMLegqkPDrsGgsWwk1Exipy2hvB0o/F0ASzbpIctSCcZIK1ykJvtTJULEH+20WOFjMvGnCTg==",
+            "dev": true,
+            "dependencies": {
+                "fromentries": "^1.2.0"
+            },
+            "engines": {
+                "node": ">=8"
+            }
+        },
         "node_modules/progress": {
             "version": "2.0.3",
             "resolved": "https://registry.npmjs.org/progress/-/progress-2.0.3.tgz",
@@ -25743,6 +26214,18 @@
             "dev": true,
             "engines": {
                 "node": ">= 0.10"
+            }
+        },
+        "node_modules/release-zalgo": {
+            "version": "1.0.0",
+            "resolved": "https://registry.npmjs.org/release-zalgo/-/release-zalgo-1.0.0.tgz",
+            "integrity": "sha512-gUAyHVHPPC5wdqX/LG4LWtRYtgjxyX78oanFNTMMyFEfOqdC54s3eE82imuWKbOeqYht2CrNf64Qb8vgmmtZGA==",
+            "dev": true,
+            "dependencies": {
+                "es6-error": "^4.0.1"
+            },
+            "engines": {
+                "node": ">=4"
             }
         },
         "node_modules/remove-trailing-separator": {
@@ -27113,6 +27596,38 @@
             "version": "0.4.1",
             "resolved": "https://registry.npmjs.org/source-map-url/-/source-map-url-0.4.1.tgz",
             "integrity": "sha512-cPiFOTLUKvJFIg4SKVScy4ilPPW6rFgMgfuZJPNoDuMs3nC1HbMUycBoJw77xFIp6z1UJQJOfx6C9GMH80DiTw=="
+        },
+        "node_modules/spawn-wrap": {
+            "version": "2.0.0",
+            "resolved": "https://registry.npmjs.org/spawn-wrap/-/spawn-wrap-2.0.0.tgz",
+            "integrity": "sha512-EeajNjfN9zMnULLwhZZQU3GWBoFNkbngTUPfaawT4RkMiviTxcX0qfhVbGey39mfctfDHkWtuecgQ8NJcyQWHg==",
+            "dev": true,
+            "dependencies": {
+                "foreground-child": "^2.0.0",
+                "is-windows": "^1.0.2",
+                "make-dir": "^3.0.0",
+                "rimraf": "^3.0.0",
+                "signal-exit": "^3.0.2",
+                "which": "^2.0.1"
+            },
+            "engines": {
+                "node": ">=8"
+            }
+        },
+        "node_modules/spawn-wrap/node_modules/which": {
+            "version": "2.0.2",
+            "resolved": "https://registry.npmjs.org/which/-/which-2.0.2.tgz",
+            "integrity": "sha512-BLI3Tl1TW3Pvl70l3yq3Y64i+awpwXqsGBYWkkqMtnbXgrMD+yj7rhW0kuEDxzJaYXGjEW5ogapKNMEKNMjibA==",
+            "dev": true,
+            "dependencies": {
+                "isexe": "^2.0.0"
+            },
+            "bin": {
+                "node-which": "bin/node-which"
+            },
+            "engines": {
+                "node": ">= 8"
+            }
         },
         "node_modules/spdx-correct": {
             "version": "3.1.1",
@@ -38585,6 +39100,16 @@
                 "debug": "4"
             }
         },
+        "aggregate-error": {
+            "version": "3.1.0",
+            "resolved": "https://registry.npmjs.org/aggregate-error/-/aggregate-error-3.1.0.tgz",
+            "integrity": "sha512-4I7Td01quW/RpocfNayFdFVk1qSuoh0E7JrbRJ16nH01HhKFQ88INq9Sd+nd72zqRySlr9BmDA8xlEJ6vJMrYA==",
+            "dev": true,
+            "requires": {
+                "clean-stack": "^2.0.0",
+                "indent-string": "^4.0.0"
+            }
+        },
         "ajv": {
             "version": "6.12.6",
             "resolved": "https://registry.npmjs.org/ajv/-/ajv-6.12.6.tgz",
@@ -38769,6 +39294,15 @@
                 }
             }
         },
+        "append-transform": {
+            "version": "2.0.0",
+            "resolved": "https://registry.npmjs.org/append-transform/-/append-transform-2.0.0.tgz",
+            "integrity": "sha512-7yeyCEurROLQJFv5Xj4lEGTy0borxepjFv1g22oAdqFu//SrAlDl1O1Nxx15SH1RoliUml6p8dwJW9jvZughhg==",
+            "dev": true,
+            "requires": {
+                "default-require-extensions": "^3.0.0"
+            }
+        },
         "aproba": {
             "version": "1.2.0",
             "resolved": "https://registry.npmjs.org/aproba/-/aproba-1.2.0.tgz",
@@ -38841,6 +39375,12 @@
                     }
                 }
             }
+        },
+        "archy": {
+            "version": "1.0.0",
+            "resolved": "https://registry.npmjs.org/archy/-/archy-1.0.0.tgz",
+            "integrity": "sha512-Xg+9RwCg/0p32teKdGMPTPnVXKD0w3DfHnFTficozsAgsvq2XenPJq/MYpzzQ/v8zrOyJn6Ds39VA4JIDwFfqw==",
+            "dev": true
         },
         "are-we-there-yet": {
             "version": "1.1.7",
@@ -40809,6 +41349,18 @@
                 }
             }
         },
+        "caching-transform": {
+            "version": "4.0.0",
+            "resolved": "https://registry.npmjs.org/caching-transform/-/caching-transform-4.0.0.tgz",
+            "integrity": "sha512-kpqOvwXnjjN44D89K5ccQC+RUrsy7jB/XLlRrx0D7/2HNcTPqzsb6XgYoErwko6QsV184CA2YgS1fxDiiDZMWA==",
+            "dev": true,
+            "requires": {
+                "hasha": "^5.0.0",
+                "make-dir": "^3.0.0",
+                "package-hash": "^4.0.0",
+                "write-file-atomic": "^3.0.0"
+            }
+        },
         "call-bind": {
             "version": "1.0.2",
             "resolved": "https://registry.npmjs.org/call-bind/-/call-bind-1.0.2.tgz",
@@ -41088,6 +41640,12 @@
                     "dev": true
                 }
             }
+        },
+        "clean-stack": {
+            "version": "2.2.0",
+            "resolved": "https://registry.npmjs.org/clean-stack/-/clean-stack-2.2.0.tgz",
+            "integrity": "sha512-4diC9HaTE+KRAMWhDhrGOECgWZxoevMc5TlkObMqNSsVU62PYzXZ/SMTjzyGAFF1YusgxGcSWTEXBhp0CPwQ1A==",
+            "dev": true
         },
         "cli-boxes": {
             "version": "2.2.1",
@@ -42331,6 +42889,15 @@
                         "isexe": "^2.0.0"
                     }
                 }
+            }
+        },
+        "default-require-extensions": {
+            "version": "3.0.0",
+            "resolved": "https://registry.npmjs.org/default-require-extensions/-/default-require-extensions-3.0.0.tgz",
+            "integrity": "sha512-ek6DpXq/SCpvjhpFsLFRVtIxJCRw6fUR42lYMVZuUMK7n8eMz4Uh5clckdBjEpLhn/gEBZo7hDJnJcwdKLKQjg==",
+            "dev": true,
+            "requires": {
+                "strip-bom": "^4.0.0"
             }
         },
         "defaults": {
@@ -43725,8 +44292,7 @@
             "version": "4.1.1",
             "resolved": "https://registry.npmjs.org/es6-error/-/es6-error-4.1.1.tgz",
             "integrity": "sha512-Um/+FxMr9CISWh0bi5Zv0iOD+4cFh5qLeks1qhAopKVAJw3drgKbKySikp7wGhDL0HPeaja0P5ULZrxLkniUVg==",
-            "dev": true,
-            "optional": true
+            "dev": true
         },
         "escalade": {
             "version": "3.1.1",
@@ -44845,6 +45411,59 @@
             "resolved": "https://registry.npmjs.org/for-in/-/for-in-1.0.2.tgz",
             "integrity": "sha1-gQaNKVqBQuwKxybG4iAMMPttXoA="
         },
+        "foreground-child": {
+            "version": "2.0.0",
+            "resolved": "https://registry.npmjs.org/foreground-child/-/foreground-child-2.0.0.tgz",
+            "integrity": "sha512-dCIq9FpEcyQyXKCkyzmlPTFNgrCzPudOe+mhvJU5zAtlBnGVy2yKxtfsxK2tQBThwq225jcvBjpw1Gr40uzZCA==",
+            "dev": true,
+            "requires": {
+                "cross-spawn": "^7.0.0",
+                "signal-exit": "^3.0.2"
+            },
+            "dependencies": {
+                "cross-spawn": {
+                    "version": "7.0.3",
+                    "resolved": "https://registry.npmjs.org/cross-spawn/-/cross-spawn-7.0.3.tgz",
+                    "integrity": "sha512-iRDPJKUPVEND7dHPO8rkbOnPpyDygcDFtWjpeWNCgy8WP2rXcxXL8TskReQl6OrB2G7+UJrags1q15Fudc7G6w==",
+                    "dev": true,
+                    "requires": {
+                        "path-key": "^3.1.0",
+                        "shebang-command": "^2.0.0",
+                        "which": "^2.0.1"
+                    }
+                },
+                "path-key": {
+                    "version": "3.1.1",
+                    "resolved": "https://registry.npmjs.org/path-key/-/path-key-3.1.1.tgz",
+                    "integrity": "sha512-ojmeN0qd+y0jszEtoY48r0Peq5dwMEkIlCOu6Q5f41lfkswXuKtYrhgoTpLnyIcHm24Uhqx+5Tqm2InSwLhE6Q==",
+                    "dev": true
+                },
+                "shebang-command": {
+                    "version": "2.0.0",
+                    "resolved": "https://registry.npmjs.org/shebang-command/-/shebang-command-2.0.0.tgz",
+                    "integrity": "sha512-kHxr2zZpYtdmrN1qDjrrX/Z1rR1kG8Dx+gkpK1G4eXmvXswmcE1hTWBWYUzlraYw1/yZp6YuDY77YtvbN0dmDA==",
+                    "dev": true,
+                    "requires": {
+                        "shebang-regex": "^3.0.0"
+                    }
+                },
+                "shebang-regex": {
+                    "version": "3.0.0",
+                    "resolved": "https://registry.npmjs.org/shebang-regex/-/shebang-regex-3.0.0.tgz",
+                    "integrity": "sha512-7++dFhtcx3353uBaq8DDR4NuxBetBzC7ZQOhmTQInHEd6bSrXdiEyzCvG07Z44UYdLShWUyXt5M/yhz8ekcb1A==",
+                    "dev": true
+                },
+                "which": {
+                    "version": "2.0.2",
+                    "resolved": "https://registry.npmjs.org/which/-/which-2.0.2.tgz",
+                    "integrity": "sha512-BLI3Tl1TW3Pvl70l3yq3Y64i+awpwXqsGBYWkkqMtnbXgrMD+yj7rhW0kuEDxzJaYXGjEW5ogapKNMEKNMjibA==",
+                    "dev": true,
+                    "requires": {
+                        "isexe": "^2.0.0"
+                    }
+                }
+            }
+        },
         "forever-agent": {
             "version": "0.6.1",
             "resolved": "https://registry.npmjs.org/forever-agent/-/forever-agent-0.6.1.tgz",
@@ -45220,6 +45839,12 @@
                 "inherits": "^2.0.1",
                 "readable-stream": "^2.0.0"
             }
+        },
+        "fromentries": {
+            "version": "1.3.2",
+            "resolved": "https://registry.npmjs.org/fromentries/-/fromentries-1.3.2.tgz",
+            "integrity": "sha512-cHEpEQHUg0f8XdtZCc2ZAhrHzKzT0MrFUTcvx+hfxYu7rGMDc5SKoXFh+n4YigxsHXRzc6OrCshdR1bWH6HHyg==",
+            "dev": true
         },
         "fs-constants": {
             "version": "1.0.0",
@@ -45861,6 +46486,30 @@
                 "minimalistic-assert": "^1.0.1"
             }
         },
+        "hasha": {
+            "version": "5.2.2",
+            "resolved": "https://registry.npmjs.org/hasha/-/hasha-5.2.2.tgz",
+            "integrity": "sha512-Hrp5vIK/xr5SkeN2onO32H0MgNZ0f17HRNH39WfL0SYUNOTZ5Lz1TJ8Pajo/87dYGEFlLMm7mIc/k/s6Bvz9HQ==",
+            "dev": true,
+            "requires": {
+                "is-stream": "^2.0.0",
+                "type-fest": "^0.8.0"
+            },
+            "dependencies": {
+                "is-stream": {
+                    "version": "2.0.1",
+                    "resolved": "https://registry.npmjs.org/is-stream/-/is-stream-2.0.1.tgz",
+                    "integrity": "sha512-hFoiJiTl63nn+kstHGBtewWSKnQLpyb155KHheA1l39uvtO9nWIop1p3udqPcUd/xbF1VLMO4n7OI6p7RbngDg==",
+                    "dev": true
+                },
+                "type-fest": {
+                    "version": "0.8.1",
+                    "resolved": "https://registry.npmjs.org/type-fest/-/type-fest-0.8.1.tgz",
+                    "integrity": "sha512-4dbzIzqvjtgiM5rw1k5rEHtBANKmdudhGyBEajN01fEyhaAIhsoKNy6y7+IN93IfpFtwY9iqi7kD+xwKhQsNJA==",
+                    "dev": true
+                }
+            }
+        },
         "he": {
             "version": "1.2.0",
             "resolved": "https://registry.npmjs.org/he/-/he-1.2.0.tgz",
@@ -46285,6 +46934,12 @@
             "version": "0.1.4",
             "resolved": "https://registry.npmjs.org/imurmurhash/-/imurmurhash-0.1.4.tgz",
             "integrity": "sha1-khi5srkoojixPcT7a21XbyMUU+o="
+        },
+        "indent-string": {
+            "version": "4.0.0",
+            "resolved": "https://registry.npmjs.org/indent-string/-/indent-string-4.0.0.tgz",
+            "integrity": "sha512-EdDDZu4A2OyIK7Lr/2zG+w5jmbuk1DVBnEwREQvBzspBJkCEbRa8GxU1lghYcaGJCnRWibjDXlq779X1/y5xwg==",
+            "dev": true
         },
         "indexes-of": {
             "version": "1.0.1",
@@ -46878,6 +47533,15 @@
             "integrity": "sha512-eOeJ5BHCmHYvQK7xt9GkdHuzuCGS1Y6g9Gvnx3Ym33fz/HpLRYxiS0wHNr+m/MBC8B647Xt608vCDEvhl9c6Mw==",
             "dev": true
         },
+        "istanbul-lib-hook": {
+            "version": "3.0.0",
+            "resolved": "https://registry.npmjs.org/istanbul-lib-hook/-/istanbul-lib-hook-3.0.0.tgz",
+            "integrity": "sha512-Pt/uge1Q9s+5VAZ+pCo16TYMWPBIl+oaNIjgLQxcX0itS6ueeaA+pEfThZpH8WxhFgCiEb8sAJY6MdUKgiIWaQ==",
+            "dev": true,
+            "requires": {
+                "append-transform": "^2.0.0"
+            }
+        },
         "istanbul-lib-instrument": {
             "version": "5.1.0",
             "resolved": "https://registry.npmjs.org/istanbul-lib-instrument/-/istanbul-lib-instrument-5.1.0.tgz",
@@ -46889,6 +47553,72 @@
                 "@istanbuljs/schema": "^0.1.2",
                 "istanbul-lib-coverage": "^3.2.0",
                 "semver": "^6.3.0"
+            }
+        },
+        "istanbul-lib-processinfo": {
+            "version": "2.0.3",
+            "resolved": "https://registry.npmjs.org/istanbul-lib-processinfo/-/istanbul-lib-processinfo-2.0.3.tgz",
+            "integrity": "sha512-NkwHbo3E00oybX6NGJi6ar0B29vxyvNwoC7eJ4G4Yq28UfY758Hgn/heV8VRFhevPED4LXfFz0DQ8z/0kw9zMg==",
+            "dev": true,
+            "requires": {
+                "archy": "^1.0.0",
+                "cross-spawn": "^7.0.3",
+                "istanbul-lib-coverage": "^3.2.0",
+                "p-map": "^3.0.0",
+                "rimraf": "^3.0.0",
+                "uuid": "^8.3.2"
+            },
+            "dependencies": {
+                "cross-spawn": {
+                    "version": "7.0.3",
+                    "resolved": "https://registry.npmjs.org/cross-spawn/-/cross-spawn-7.0.3.tgz",
+                    "integrity": "sha512-iRDPJKUPVEND7dHPO8rkbOnPpyDygcDFtWjpeWNCgy8WP2rXcxXL8TskReQl6OrB2G7+UJrags1q15Fudc7G6w==",
+                    "dev": true,
+                    "requires": {
+                        "path-key": "^3.1.0",
+                        "shebang-command": "^2.0.0",
+                        "which": "^2.0.1"
+                    }
+                },
+                "p-map": {
+                    "version": "3.0.0",
+                    "resolved": "https://registry.npmjs.org/p-map/-/p-map-3.0.0.tgz",
+                    "integrity": "sha512-d3qXVTF/s+W+CdJ5A29wywV2n8CQQYahlgz2bFiA+4eVNJbHJodPZ+/gXwPGh0bOqA+j8S+6+ckmvLGPk1QpxQ==",
+                    "dev": true,
+                    "requires": {
+                        "aggregate-error": "^3.0.0"
+                    }
+                },
+                "path-key": {
+                    "version": "3.1.1",
+                    "resolved": "https://registry.npmjs.org/path-key/-/path-key-3.1.1.tgz",
+                    "integrity": "sha512-ojmeN0qd+y0jszEtoY48r0Peq5dwMEkIlCOu6Q5f41lfkswXuKtYrhgoTpLnyIcHm24Uhqx+5Tqm2InSwLhE6Q==",
+                    "dev": true
+                },
+                "shebang-command": {
+                    "version": "2.0.0",
+                    "resolved": "https://registry.npmjs.org/shebang-command/-/shebang-command-2.0.0.tgz",
+                    "integrity": "sha512-kHxr2zZpYtdmrN1qDjrrX/Z1rR1kG8Dx+gkpK1G4eXmvXswmcE1hTWBWYUzlraYw1/yZp6YuDY77YtvbN0dmDA==",
+                    "dev": true,
+                    "requires": {
+                        "shebang-regex": "^3.0.0"
+                    }
+                },
+                "shebang-regex": {
+                    "version": "3.0.0",
+                    "resolved": "https://registry.npmjs.org/shebang-regex/-/shebang-regex-3.0.0.tgz",
+                    "integrity": "sha512-7++dFhtcx3353uBaq8DDR4NuxBetBzC7ZQOhmTQInHEd6bSrXdiEyzCvG07Z44UYdLShWUyXt5M/yhz8ekcb1A==",
+                    "dev": true
+                },
+                "which": {
+                    "version": "2.0.2",
+                    "resolved": "https://registry.npmjs.org/which/-/which-2.0.2.tgz",
+                    "integrity": "sha512-BLI3Tl1TW3Pvl70l3yq3Y64i+awpwXqsGBYWkkqMtnbXgrMD+yj7rhW0kuEDxzJaYXGjEW5ogapKNMEKNMjibA==",
+                    "dev": true,
+                    "requires": {
+                        "isexe": "^2.0.0"
+                    }
+                }
             }
         },
         "istanbul-lib-report": {
@@ -50430,6 +51160,12 @@
             "integrity": "sha512-3j8wdDzYuWO3lM3Reg03MuQR957t287Rpcxp1njpEa8oDrikb+FwGdW3n+FELh/A6qib6yPit0j/pv9G/yeAqA==",
             "dev": true
         },
+        "lodash.flattendeep": {
+            "version": "4.4.0",
+            "resolved": "https://registry.npmjs.org/lodash.flattendeep/-/lodash.flattendeep-4.4.0.tgz",
+            "integrity": "sha512-uHaJFihxmJcEX3kT4I23ABqKKalJ/zDrDg0lsFtc1h+3uw49SIJ5beyhx5ExVRti3AvKoOJngIj7xz3oylPdWQ==",
+            "dev": true
+        },
         "lodash.get": {
             "version": "4.4.2",
             "resolved": "https://registry.npmjs.org/lodash.get/-/lodash.get-4.4.2.tgz",
@@ -51553,6 +52289,15 @@
                 }
             }
         },
+        "node-preload": {
+            "version": "0.2.1",
+            "resolved": "https://registry.npmjs.org/node-preload/-/node-preload-0.2.1.tgz",
+            "integrity": "sha512-RM5oyBy45cLEoHqCeh+MNuFAxO0vTFBLskvQbOKnEE7YTTSN4tbN8QWDIPQ6L+WvKsB/qLEGpYe2ZZ9d4W9OIQ==",
+            "dev": true,
+            "requires": {
+                "process-on-spawn": "^1.0.0"
+            }
+        },
         "node-releases": {
             "version": "2.0.1",
             "resolved": "https://registry.npmjs.org/node-releases/-/node-releases-2.0.1.tgz",
@@ -51877,6 +52622,105 @@
             "resolved": "https://registry.npmjs.org/nwsapi/-/nwsapi-2.2.0.tgz",
             "integrity": "sha512-h2AatdwYH+JHiZpv7pt/gSX1XoRGb7L/qSIeuqA6GwYoF9w1vP1cw42TO0aI2pNyshRK5893hNSl+1//vHK7hQ==",
             "dev": true
+        },
+        "nyc": {
+            "version": "15.1.0",
+            "resolved": "https://registry.npmjs.org/nyc/-/nyc-15.1.0.tgz",
+            "integrity": "sha512-jMW04n9SxKdKi1ZMGhvUTHBN0EICCRkHemEoE5jm6mTYcqcdas0ATzgUgejlQUHMvpnOZqGB5Xxsv9KxJW1j8A==",
+            "dev": true,
+            "requires": {
+                "@istanbuljs/load-nyc-config": "^1.0.0",
+                "@istanbuljs/schema": "^0.1.2",
+                "caching-transform": "^4.0.0",
+                "convert-source-map": "^1.7.0",
+                "decamelize": "^1.2.0",
+                "find-cache-dir": "^3.2.0",
+                "find-up": "^4.1.0",
+                "foreground-child": "^2.0.0",
+                "get-package-type": "^0.1.0",
+                "glob": "^7.1.6",
+                "istanbul-lib-coverage": "^3.0.0",
+                "istanbul-lib-hook": "^3.0.0",
+                "istanbul-lib-instrument": "^4.0.0",
+                "istanbul-lib-processinfo": "^2.0.2",
+                "istanbul-lib-report": "^3.0.0",
+                "istanbul-lib-source-maps": "^4.0.0",
+                "istanbul-reports": "^3.0.2",
+                "make-dir": "^3.0.0",
+                "node-preload": "^0.2.1",
+                "p-map": "^3.0.0",
+                "process-on-spawn": "^1.0.0",
+                "resolve-from": "^5.0.0",
+                "rimraf": "^3.0.0",
+                "signal-exit": "^3.0.2",
+                "spawn-wrap": "^2.0.0",
+                "test-exclude": "^6.0.0",
+                "yargs": "^15.0.2"
+            },
+            "dependencies": {
+                "camelcase": {
+                    "version": "5.3.1",
+                    "resolved": "https://registry.npmjs.org/camelcase/-/camelcase-5.3.1.tgz",
+                    "integrity": "sha512-L28STB170nwWS63UjtlEOE3dldQApaJXZkOI1uMFfzf3rRuPegHaHesyee+YxQ+W6SvRDQV6UrdOdRiR153wJg==",
+                    "dev": true
+                },
+                "decamelize": {
+                    "version": "1.2.0",
+                    "resolved": "https://registry.npmjs.org/decamelize/-/decamelize-1.2.0.tgz",
+                    "integrity": "sha512-z2S+W9X73hAUUki+N+9Za2lBlun89zigOyGrsax+KUQ6wKW4ZoWpEYBkGhQjwAjjDCkWxhY0VKEhk8wzY7F5cA==",
+                    "dev": true
+                },
+                "istanbul-lib-instrument": {
+                    "version": "4.0.3",
+                    "resolved": "https://registry.npmjs.org/istanbul-lib-instrument/-/istanbul-lib-instrument-4.0.3.tgz",
+                    "integrity": "sha512-BXgQl9kf4WTCPCCpmFGoJkz/+uhvm7h7PFKUYxh7qarQd3ER33vHG//qaE8eN25l07YqZPpHXU9I09l/RD5aGQ==",
+                    "dev": true,
+                    "requires": {
+                        "@babel/core": "^7.7.5",
+                        "@istanbuljs/schema": "^0.1.2",
+                        "istanbul-lib-coverage": "^3.0.0",
+                        "semver": "^6.3.0"
+                    }
+                },
+                "p-map": {
+                    "version": "3.0.0",
+                    "resolved": "https://registry.npmjs.org/p-map/-/p-map-3.0.0.tgz",
+                    "integrity": "sha512-d3qXVTF/s+W+CdJ5A29wywV2n8CQQYahlgz2bFiA+4eVNJbHJodPZ+/gXwPGh0bOqA+j8S+6+ckmvLGPk1QpxQ==",
+                    "dev": true,
+                    "requires": {
+                        "aggregate-error": "^3.0.0"
+                    }
+                },
+                "yargs": {
+                    "version": "15.4.1",
+                    "resolved": "https://registry.npmjs.org/yargs/-/yargs-15.4.1.tgz",
+                    "integrity": "sha512-aePbxDmcYW++PaqBsJ+HYUFwCdv4LVvdnhBy78E57PIor8/OVvhMrADFFEDh8DHDFRv/O9i3lPhsENjO7QX0+A==",
+                    "dev": true,
+                    "requires": {
+                        "cliui": "^6.0.0",
+                        "decamelize": "^1.2.0",
+                        "find-up": "^4.1.0",
+                        "get-caller-file": "^2.0.1",
+                        "require-directory": "^2.1.1",
+                        "require-main-filename": "^2.0.0",
+                        "set-blocking": "^2.0.0",
+                        "string-width": "^4.2.0",
+                        "which-module": "^2.0.0",
+                        "y18n": "^4.0.0",
+                        "yargs-parser": "^18.1.2"
+                    }
+                },
+                "yargs-parser": {
+                    "version": "18.1.3",
+                    "resolved": "https://registry.npmjs.org/yargs-parser/-/yargs-parser-18.1.3.tgz",
+                    "integrity": "sha512-o50j0JeToy/4K6OZcaQmW6lyXXKhq7csREXcDwk2omFPJEwUNOVtJKvmDr9EI1fAJZUyZcRF7kxGBWmRXudrCQ==",
+                    "dev": true,
+                    "requires": {
+                        "camelcase": "^5.0.0",
+                        "decamelize": "^1.2.0"
+                    }
+                }
+            }
         },
         "oauth-sign": {
             "version": "0.9.0",
@@ -52266,6 +53110,18 @@
             "version": "2.2.0",
             "resolved": "https://registry.npmjs.org/p-try/-/p-try-2.2.0.tgz",
             "integrity": "sha512-R4nPAVTAU0B9D35/Gk3uJf/7XYbQcyohSKdvAxIRSNghFl4e71hVoGnBNQz9cWaXxO2I10KTC+3jMdvvoKw6dQ=="
+        },
+        "package-hash": {
+            "version": "4.0.0",
+            "resolved": "https://registry.npmjs.org/package-hash/-/package-hash-4.0.0.tgz",
+            "integrity": "sha512-whdkPIooSu/bASggZ96BWVvZTRMOFxnyUG5PnTSGKoJE2gd5mbVNmR2Nj20QFzxYYgAXpoqC+AiXzl+UMRh7zQ==",
+            "dev": true,
+            "requires": {
+                "graceful-fs": "^4.1.15",
+                "hasha": "^5.0.0",
+                "lodash.flattendeep": "^4.4.0",
+                "release-zalgo": "^1.0.0"
+            }
         },
         "package-json": {
             "version": "6.5.0",
@@ -53407,6 +54263,15 @@
             "resolved": "https://registry.npmjs.org/process-nextick-args/-/process-nextick-args-2.0.1.tgz",
             "integrity": "sha512-3ouUOpQhtgrbOa17J7+uxOTpITYWaGP7/AhoR3+A+/1e9skrzelGi/dXzEYyvbxubEF6Wn2ypscTKiKJFFn1ag=="
         },
+        "process-on-spawn": {
+            "version": "1.0.0",
+            "resolved": "https://registry.npmjs.org/process-on-spawn/-/process-on-spawn-1.0.0.tgz",
+            "integrity": "sha512-1WsPDsUSMmZH5LeMLegqkPDrsGgsWwk1Exipy2hvB0o/F0ASzbpIctSCcZIK1ykJvtTJULEH+20WOFjMvGnCTg==",
+            "dev": true,
+            "requires": {
+                "fromentries": "^1.2.0"
+            }
+        },
         "progress": {
             "version": "2.0.3",
             "resolved": "https://registry.npmjs.org/progress/-/progress-2.0.3.tgz",
@@ -54059,6 +54924,15 @@
             "resolved": "https://registry.npmjs.org/relateurl/-/relateurl-0.2.7.tgz",
             "integrity": "sha1-VNvzd+UUQKypCkzSdGANP/LYiKk=",
             "dev": true
+        },
+        "release-zalgo": {
+            "version": "1.0.0",
+            "resolved": "https://registry.npmjs.org/release-zalgo/-/release-zalgo-1.0.0.tgz",
+            "integrity": "sha512-gUAyHVHPPC5wdqX/LG4LWtRYtgjxyX78oanFNTMMyFEfOqdC54s3eE82imuWKbOeqYht2CrNf64Qb8vgmmtZGA==",
+            "dev": true,
+            "requires": {
+                "es6-error": "^4.0.1"
+            }
         },
         "remove-trailing-separator": {
             "version": "1.1.0",
@@ -55198,6 +56072,31 @@
             "version": "0.4.1",
             "resolved": "https://registry.npmjs.org/source-map-url/-/source-map-url-0.4.1.tgz",
             "integrity": "sha512-cPiFOTLUKvJFIg4SKVScy4ilPPW6rFgMgfuZJPNoDuMs3nC1HbMUycBoJw77xFIp6z1UJQJOfx6C9GMH80DiTw=="
+        },
+        "spawn-wrap": {
+            "version": "2.0.0",
+            "resolved": "https://registry.npmjs.org/spawn-wrap/-/spawn-wrap-2.0.0.tgz",
+            "integrity": "sha512-EeajNjfN9zMnULLwhZZQU3GWBoFNkbngTUPfaawT4RkMiviTxcX0qfhVbGey39mfctfDHkWtuecgQ8NJcyQWHg==",
+            "dev": true,
+            "requires": {
+                "foreground-child": "^2.0.0",
+                "is-windows": "^1.0.2",
+                "make-dir": "^3.0.0",
+                "rimraf": "^3.0.0",
+                "signal-exit": "^3.0.2",
+                "which": "^2.0.1"
+            },
+            "dependencies": {
+                "which": {
+                    "version": "2.0.2",
+                    "resolved": "https://registry.npmjs.org/which/-/which-2.0.2.tgz",
+                    "integrity": "sha512-BLI3Tl1TW3Pvl70l3yq3Y64i+awpwXqsGBYWkkqMtnbXgrMD+yj7rhW0kuEDxzJaYXGjEW5ogapKNMEKNMjibA==",
+                    "dev": true,
+                    "requires": {
+                        "isexe": "^2.0.0"
+                    }
+                }
+            }
         },
         "spdx-correct": {
             "version": "3.1.1",

--- a/package.json
+++ b/package.json
@@ -129,6 +129,7 @@
         "node-pre-gyp": "^0.13.0",
         "npm-build-zip": "^1.0.2",
         "nth-check": ">=2.0.1",
+        "nyc": "^15.1.0",
         "postcss-import": "^12.0.1",
         "postcss-pxtorem": "^4.0.1",
         "prettier": "2.0.5",

--- a/scripts/ci/test.sh
+++ b/scripts/ci/test.sh
@@ -4,3 +4,7 @@ set -ex
 
 TEST_MODE=$([ "$1" = "code-coverage" ] && echo "test:jenkins" || echo "test")
 npm run "${TEST_MODE}"
+
+# copy jest coverage json report to .nyc_output so that ci coverage threshold check can work
+cd $(git rev-parse --show-toplevel)
+mkdir -p .nyc_output && cp ./coverage/coverage-final.json ./.nyc_output 2>/dev/null || :


### PR DESCRIPTION
## What was the issue?
* CI unit test coverage threshold check was not enabled
* `desktop-wallet` is using Jest test runner and CI was using `nyc` to check target the coverage threshold, needed to find a way to integrate these two

## What's the fix
* Enabled the CI unit test coverage threshold check (currently it's %27 in order not to let the build fail)
* Integrated `nyc` to be able to check if the minimum target coverage is met in the CI