### PR TITLE
[wallet/desktop] task: unit tests added for Message components

### DIFF
--- a/__tests__/components/MessageDisplay.spec.ts
+++ b/__tests__/components/MessageDisplay.spec.ts
@@ -1,0 +1,273 @@
+/*
+ * (C) Symbol Contributors 2022
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and limitations under the License.
+ *
+ */
+import MessageDisplay from '@/components/MessageDisplay/MessageDisplay.vue';
+import { MessageDisplayTs } from '@/components/MessageDisplay/MessageDisplayTs';
+import { NotificationType } from '@/core/utils/NotificationType';
+import { getComponent } from '@MOCKS/Components';
+import { WalletsModel1, account1 } from '@MOCKS/Accounts';
+import { Account, Address, EncryptedMessage, NamespaceId, PlainMessage, PublicAccount, UnresolvedAddress } from 'symbol-sdk';
+
+const messageDisplayTs = new MessageDisplayTs();
+type Props = typeof messageDisplayTs.$props;
+
+describe('components/MessageDisplay', () => {
+    const networkType = 152;
+    const defaultRecipientPublicAccount = Account.generateNewAccount(networkType).publicAccount;
+
+    const getMessageDisplayWrapper = (
+        props: Props,
+        recipientPublicAccount = defaultRecipientPublicAccount,
+        linkedAddress: null | Address = null,
+        dispatch?: () => any,
+    ) => {
+        const mockStore = {
+            account: {
+                namespaced: true,
+                getters: {
+                    currentAccount: () => WalletsModel1,
+                    currentRecipient: () => recipientPublicAccount,
+                },
+            },
+            namespace: {
+                namespaced: true,
+                getters: {
+                    linkedAddress: () => linkedAddress,
+                },
+            },
+        };
+
+        return getComponent(MessageDisplay, mockStore, {}, props, {}, dispatch);
+    };
+
+    describe('loadDetails()', () => {
+        const runLoadDetailsTest = async (
+            unannounced: boolean,
+            message: PlainMessage | EncryptedMessage,
+            expectedMessageDisplay: string,
+        ) => {
+            // Arrange:
+            const props = {
+                message,
+                unannounced,
+            };
+            const mockT = jest.fn().mockImplementation((_) => _);
+
+            // Act:
+            const wrapper = getMessageDisplayWrapper(props);
+            const vm = wrapper.vm as MessageDisplayTs;
+            vm['$t'] = mockT;
+            vm['loadDetails']();
+            const messageDisplay = vm['messageDisplay'];
+
+            // Assert:
+            expect(messageDisplay).toBe(expectedMessageDisplay);
+        };
+
+        test('message is encrypted and tx is unannounced', async () => {
+            // Arrange:
+            const unannounced = true;
+            const message = EncryptedMessage.create('message', account1.publicAccount, account1.privateKey);
+            const expectedMessageDisplay = `${message.payload} (encrypted_message)`;
+
+            // Act + Assert:
+            await runLoadDetailsTest(unannounced, message, expectedMessageDisplay);
+        });
+
+        test('message is encrypted and tx is announced', async () => {
+            // Arrange:
+            const unannounced = false;
+            const message = EncryptedMessage.create('message', account1.publicAccount, account1.privateKey);
+            const expectedMessageDisplay = '******';
+
+            // Act + Assert:
+            await runLoadDetailsTest(unannounced, message, expectedMessageDisplay);
+        });
+
+        test('message is unencrypted', async () => {
+            // Arrange:
+            const unannounced = false;
+            const message = PlainMessage.create('message');
+            const expectedMessageDisplay = 'message';
+
+            // Act + Assert:
+            await runLoadDetailsTest(unannounced, message, expectedMessageDisplay);
+        });
+    });
+
+    describe('onAccountUnlocked()', () => {
+        const runUnlockAccountTest = async (
+            recipient: UnresolvedAddress,
+            linkedAddress: Address | null,
+            decryptAddress: Address | null,
+            expectGetLinkedAddressToBeDispatched: boolean,
+            expectAddErrorToBeDispatched: boolean,
+            expecDecryptMessageToBeCalled: boolean,
+        ) => {
+            // Arrange:
+            const currentAccount = account1;
+            const message = PlainMessage.create('message');
+            const unannounced = false;
+            const props = {
+                message,
+                recipient,
+                unannounced,
+            };
+            const mockDispatch = jest.fn().mockImplementation(() => Promise.resolve());
+            const mockDecryptMessage = jest.fn();
+            const mockT = jest.fn().mockImplementation((_) => _);
+
+            // Act:
+            const wrapper = getMessageDisplayWrapper(props, null, linkedAddress, mockDispatch);
+            const vm = wrapper.vm as MessageDisplayTs;
+            vm['decryptMessage'] = mockDecryptMessage;
+            vm['$t'] = mockT;
+            vm['onAccountUnlocked'](currentAccount);
+            await new Promise(process.nextTick);
+
+            // Assert:
+            if (expectGetLinkedAddressToBeDispatched) {
+                expect(mockDispatch).toHaveBeenNthCalledWith(1, 'namespace/GET_LINKED_ADDRESS', recipient);
+            } else {
+                expect(mockDispatch).not.toHaveBeenNthCalledWith(1, 'namespace/GET_LINKED_ADDRESS', recipient);
+            }
+
+            if (expectAddErrorToBeDispatched) {
+                expect(mockDispatch).toHaveBeenNthCalledWith(
+                    2,
+                    'notification/ADD_ERROR',
+                    NotificationType.RECIPIENT_LINKED_ADDRESS_INVALID,
+                );
+            } else {
+                expect(mockDispatch).not.toHaveBeenNthCalledWith(
+                    2,
+                    'notification/ADD_ERROR',
+                    NotificationType.RECIPIENT_LINKED_ADDRESS_INVALID,
+                );
+            }
+
+            if (expecDecryptMessageToBeCalled) {
+                expect(mockDecryptMessage).toBeCalledWith(currentAccount.privateKey, decryptAddress);
+            } else {
+                expect(mockDecryptMessage).not.toBeCalledWith(currentAccount.privateKey, decryptAddress);
+            }
+        };
+
+        test('recipient is instance of NamespaceId and linkedAddress is provided', async () => {
+            // Arrange:
+            const recipient = new NamespaceId([929036875, 2226345261]);
+            const linkedAddress = account1.address;
+            const decryptAddress = linkedAddress;
+            const expectGetLinkedAddressToBeDispatched = true;
+            const expectAddErrorToBeDispatched = false;
+            const expecDecryptMessageToBeCalled = true;
+
+            // Act + Assert:
+            await runUnlockAccountTest(
+                recipient,
+                linkedAddress,
+                decryptAddress,
+                expectGetLinkedAddressToBeDispatched,
+                expectAddErrorToBeDispatched,
+                expecDecryptMessageToBeCalled,
+            );
+        });
+
+        test('recipient is instance of NamespaceId and no linkedAddress is provided', async () => {
+            // Arrange:
+            const recipient = new NamespaceId([929036875, 2226345261]);
+            const linkedAddress = null;
+            const decryptAddress = null;
+            const expectGetLinkedAddressToBeDispatched = true;
+            const expectAddErrorToBeDispatched = true;
+            const expecDecryptMessageToBeCalled = false;
+
+            // Act + Assert:
+            await runUnlockAccountTest(
+                recipient,
+                linkedAddress,
+                decryptAddress,
+                expectGetLinkedAddressToBeDispatched,
+                expectAddErrorToBeDispatched,
+                expecDecryptMessageToBeCalled,
+            );
+        });
+
+        test('recipient is instance of Address', async () => {
+            // Arrange:
+            const recipient = account1.address;
+            const linkedAddress = null;
+            const decryptAddress = account1.address;
+            const expectGetLinkedAddressToBeDispatched = false;
+            const expectAddErrorToBeDispatched = false;
+            const expecDecryptMessageToBeCalled = true;
+
+            // Act + Assert:
+            await runUnlockAccountTest(
+                recipient,
+                linkedAddress,
+                decryptAddress,
+                expectGetLinkedAddressToBeDispatched,
+                expectAddErrorToBeDispatched,
+                expecDecryptMessageToBeCalled,
+            );
+        });
+    });
+
+    describe('decryptMessage()', () => {
+        const runDecryptMessageTest = async (signer: PublicAccount, recipient: PublicAccount) => {
+            // Arrange:
+            const currentAccount = account1;
+            const message = EncryptedMessage.create('message', recipient, currentAccount.privateKey);
+            const expectedDecryptedMessage = PlainMessage.create('message');
+            const props = {
+                message,
+                signer,
+                recipient: recipient.address,
+            };
+            const dispatch = jest.fn().mockImplementation(() => {
+                return Promise.resolve();
+            });
+
+            // Act:
+            const vm = getMessageDisplayWrapper(props, recipient, null, dispatch).vm as MessageDisplayTs;
+            vm['decryptMessage'](currentAccount.privateKey, recipient.address);
+            await vm.$nextTick();
+
+            // Assert:
+            expect(vm['isEncrypted']).toBe(false);
+            expect(vm['decryptedMessage']).toStrictEqual(expectedDecryptedMessage);
+            expect(vm['messageDisplay']).toBe(expectedDecryptedMessage.payload);
+        };
+
+        test('recipient is current account', async () => {
+            // Arrange:
+            const signer = account1.publicAccount;
+            const recipient = signer;
+
+            // Act + Assert:
+            await runDecryptMessageTest(signer, recipient);
+        });
+
+        test('recipient is random account', async () => {
+            // Arrange:
+            const signer = account1.publicAccount;
+            const recipient = Account.generateNewAccount(networkType).publicAccount;
+
+            // Act + Assert:
+            await runDecryptMessageTest(signer, recipient);
+        });
+    });
+});

--- a/__tests__/components/MessageDisplay.spec.ts
+++ b/__tests__/components/MessageDisplay.spec.ts
@@ -20,8 +20,7 @@ import { getComponent } from '@MOCKS/Components';
 import { WalletsModel1, account1 } from '@MOCKS/Accounts';
 import { Account, Address, EncryptedMessage, NamespaceId, PlainMessage, PublicAccount, UnresolvedAddress } from 'symbol-sdk';
 
-const messageDisplayTs = new MessageDisplayTs();
-type Props = typeof messageDisplayTs.$props;
+type Props = InstanceType<typeof MessageDisplayTs>['$props'];
 
 describe('components/MessageDisplay', () => {
     const networkType = 152;

--- a/__tests__/components/MessageDisplay.spec.ts
+++ b/__tests__/components/MessageDisplay.spec.ts
@@ -107,21 +107,21 @@ describe('components/MessageDisplay', () => {
     });
 
     describe('onAccountUnlocked()', () => {
-        const runUnlockAccountTest = async (
-            recipient: UnresolvedAddress,
-            linkedAddress: Address | null,
-            decryptAddress: Address | null,
-            expectGetLinkedAddressToBeDispatched: boolean,
-            expectAddErrorToBeDispatched: boolean,
-            expecDecryptMessageToBeCalled: boolean,
-        ) => {
+        const runUnlockAccountTest = async (options: {
+            recipient: UnresolvedAddress;
+            linkedAddress: Address | null;
+            decryptAddress: Address | null;
+            expectGetLinkedAddressToBeDispatched: boolean;
+            expectAddErrorToBeDispatched: boolean;
+            expectDecryptMessageToBeCalled: boolean;
+        }) => {
             // Arrange:
             const currentAccount = account1;
             const message = PlainMessage.create('message');
             const unannounced = false;
             const props = {
                 message,
-                recipient,
+                recipient: options.recipient,
                 unannounced,
             };
             const mockDispatch = jest.fn().mockImplementation(() => Promise.resolve());
@@ -129,7 +129,7 @@ describe('components/MessageDisplay', () => {
             const mockT = jest.fn().mockImplementation((_) => _);
 
             // Act:
-            const wrapper = getMessageDisplayWrapper(props, null, linkedAddress, mockDispatch);
+            const wrapper = getMessageDisplayWrapper(props, null, options.linkedAddress, mockDispatch);
             const vm = wrapper.vm as MessageDisplayTs;
             vm['decryptMessage'] = mockDecryptMessage;
             vm['$t'] = mockT;
@@ -137,13 +137,13 @@ describe('components/MessageDisplay', () => {
             await new Promise(process.nextTick);
 
             // Assert:
-            if (expectGetLinkedAddressToBeDispatched) {
-                expect(mockDispatch).toHaveBeenNthCalledWith(1, 'namespace/GET_LINKED_ADDRESS', recipient);
+            if (options.expectGetLinkedAddressToBeDispatched) {
+                expect(mockDispatch).toHaveBeenNthCalledWith(1, 'namespace/GET_LINKED_ADDRESS', options.recipient);
             } else {
-                expect(mockDispatch).not.toHaveBeenNthCalledWith(1, 'namespace/GET_LINKED_ADDRESS', recipient);
+                expect(mockDispatch).not.toHaveBeenNthCalledWith(1, 'namespace/GET_LINKED_ADDRESS', options.recipient);
             }
 
-            if (expectAddErrorToBeDispatched) {
+            if (options.expectAddErrorToBeDispatched) {
                 expect(mockDispatch).toHaveBeenNthCalledWith(
                     2,
                     'notification/ADD_ERROR',
@@ -157,10 +157,10 @@ describe('components/MessageDisplay', () => {
                 );
             }
 
-            if (expecDecryptMessageToBeCalled) {
-                expect(mockDecryptMessage).toBeCalledWith(currentAccount.privateKey, decryptAddress);
+            if (options.expectDecryptMessageToBeCalled) {
+                expect(mockDecryptMessage).toBeCalledWith(currentAccount.privateKey, options.decryptAddress);
             } else {
-                expect(mockDecryptMessage).not.toBeCalledWith(currentAccount.privateKey, decryptAddress);
+                expect(mockDecryptMessage).not.toBeCalledWith(currentAccount.privateKey, options.decryptAddress);
             }
         };
 
@@ -171,17 +171,17 @@ describe('components/MessageDisplay', () => {
             const decryptAddress = linkedAddress;
             const expectGetLinkedAddressToBeDispatched = true;
             const expectAddErrorToBeDispatched = false;
-            const expecDecryptMessageToBeCalled = true;
+            const expectDecryptMessageToBeCalled = true;
 
             // Act + Assert:
-            await runUnlockAccountTest(
+            await runUnlockAccountTest({
                 recipient,
                 linkedAddress,
                 decryptAddress,
                 expectGetLinkedAddressToBeDispatched,
                 expectAddErrorToBeDispatched,
-                expecDecryptMessageToBeCalled,
-            );
+                expectDecryptMessageToBeCalled,
+            });
         });
 
         test('recipient is instance of NamespaceId and no linkedAddress is provided', async () => {
@@ -191,17 +191,17 @@ describe('components/MessageDisplay', () => {
             const decryptAddress = null;
             const expectGetLinkedAddressToBeDispatched = true;
             const expectAddErrorToBeDispatched = true;
-            const expecDecryptMessageToBeCalled = false;
+            const expectDecryptMessageToBeCalled = false;
 
             // Act + Assert:
-            await runUnlockAccountTest(
+            await runUnlockAccountTest({
                 recipient,
                 linkedAddress,
                 decryptAddress,
                 expectGetLinkedAddressToBeDispatched,
                 expectAddErrorToBeDispatched,
-                expecDecryptMessageToBeCalled,
-            );
+                expectDecryptMessageToBeCalled,
+            });
         });
 
         test('recipient is instance of Address', async () => {
@@ -211,17 +211,17 @@ describe('components/MessageDisplay', () => {
             const decryptAddress = account1.address;
             const expectGetLinkedAddressToBeDispatched = false;
             const expectAddErrorToBeDispatched = false;
-            const expecDecryptMessageToBeCalled = true;
+            const expectDecryptMessageToBeCalled = true;
 
             // Act + Assert:
-            await runUnlockAccountTest(
+            await runUnlockAccountTest({
                 recipient,
                 linkedAddress,
                 decryptAddress,
                 expectGetLinkedAddressToBeDispatched,
                 expectAddErrorToBeDispatched,
-                expecDecryptMessageToBeCalled,
-            );
+                expectDecryptMessageToBeCalled,
+            });
         });
     });
 

--- a/__tests__/components/MessageDisplay.spec.ts
+++ b/__tests__/components/MessageDisplay.spec.ts
@@ -107,21 +107,23 @@ describe('components/MessageDisplay', () => {
     });
 
     describe('onAccountUnlocked()', () => {
-        const runUnlockAccountTest = async (options: {
-            recipient: UnresolvedAddress;
-            linkedAddress: Address | null;
-            decryptAddress: Address | null;
-            expectGetLinkedAddressToBeDispatched: boolean;
-            expectAddErrorToBeDispatched: boolean;
-            expectDecryptMessageToBeCalled: boolean;
-        }) => {
+        const runUnlockAccountTest = async (
+            recipient: UnresolvedAddress,
+            linkedAddress: Address | null,
+            decryptAddress: Address | null,
+            expectations: {
+                getLinkedAddressToBeDispatched: boolean;
+                addErrorToBeDispatched: boolean;
+                decryptMessageToBeCalled: boolean;
+            },
+        ) => {
             // Arrange:
             const currentAccount = account1;
             const message = PlainMessage.create('message');
             const unannounced = false;
             const props = {
                 message,
-                recipient: options.recipient,
+                recipient,
                 unannounced,
             };
             const mockDispatch = jest.fn().mockImplementation(() => Promise.resolve());
@@ -129,7 +131,7 @@ describe('components/MessageDisplay', () => {
             const mockT = jest.fn().mockImplementation((_) => _);
 
             // Act:
-            const wrapper = getMessageDisplayWrapper(props, null, options.linkedAddress, mockDispatch);
+            const wrapper = getMessageDisplayWrapper(props, null, linkedAddress, mockDispatch);
             const vm = wrapper.vm as MessageDisplayTs;
             vm['decryptMessage'] = mockDecryptMessage;
             vm['$t'] = mockT;
@@ -137,13 +139,13 @@ describe('components/MessageDisplay', () => {
             await new Promise(process.nextTick);
 
             // Assert:
-            if (options.expectGetLinkedAddressToBeDispatched) {
-                expect(mockDispatch).toHaveBeenNthCalledWith(1, 'namespace/GET_LINKED_ADDRESS', options.recipient);
+            if (expectations.getLinkedAddressToBeDispatched) {
+                expect(mockDispatch).toHaveBeenNthCalledWith(1, 'namespace/GET_LINKED_ADDRESS', recipient);
             } else {
-                expect(mockDispatch).not.toHaveBeenNthCalledWith(1, 'namespace/GET_LINKED_ADDRESS', options.recipient);
+                expect(mockDispatch).not.toHaveBeenNthCalledWith(1, 'namespace/GET_LINKED_ADDRESS', recipient);
             }
 
-            if (options.expectAddErrorToBeDispatched) {
+            if (expectations.addErrorToBeDispatched) {
                 expect(mockDispatch).toHaveBeenNthCalledWith(
                     2,
                     'notification/ADD_ERROR',
@@ -157,10 +159,10 @@ describe('components/MessageDisplay', () => {
                 );
             }
 
-            if (options.expectDecryptMessageToBeCalled) {
-                expect(mockDecryptMessage).toBeCalledWith(currentAccount.privateKey, options.decryptAddress);
+            if (expectations.decryptMessageToBeCalled) {
+                expect(mockDecryptMessage).toBeCalledWith(currentAccount.privateKey, decryptAddress);
             } else {
-                expect(mockDecryptMessage).not.toBeCalledWith(currentAccount.privateKey, options.decryptAddress);
+                expect(mockDecryptMessage).not.toBeCalledWith(currentAccount.privateKey, decryptAddress);
             }
         };
 
@@ -169,18 +171,12 @@ describe('components/MessageDisplay', () => {
             const recipient = new NamespaceId([929036875, 2226345261]);
             const linkedAddress = account1.address;
             const decryptAddress = linkedAddress;
-            const expectGetLinkedAddressToBeDispatched = true;
-            const expectAddErrorToBeDispatched = false;
-            const expectDecryptMessageToBeCalled = true;
 
             // Act + Assert:
-            await runUnlockAccountTest({
-                recipient,
-                linkedAddress,
-                decryptAddress,
-                expectGetLinkedAddressToBeDispatched,
-                expectAddErrorToBeDispatched,
-                expectDecryptMessageToBeCalled,
+            await runUnlockAccountTest(recipient, linkedAddress, decryptAddress, {
+                getLinkedAddressToBeDispatched: true,
+                addErrorToBeDispatched: false,
+                decryptMessageToBeCalled: true,
             });
         });
 
@@ -189,18 +185,12 @@ describe('components/MessageDisplay', () => {
             const recipient = new NamespaceId([929036875, 2226345261]);
             const linkedAddress = null;
             const decryptAddress = null;
-            const expectGetLinkedAddressToBeDispatched = true;
-            const expectAddErrorToBeDispatched = true;
-            const expectDecryptMessageToBeCalled = false;
 
             // Act + Assert:
-            await runUnlockAccountTest({
-                recipient,
-                linkedAddress,
-                decryptAddress,
-                expectGetLinkedAddressToBeDispatched,
-                expectAddErrorToBeDispatched,
-                expectDecryptMessageToBeCalled,
+            await runUnlockAccountTest(recipient, linkedAddress, decryptAddress, {
+                getLinkedAddressToBeDispatched: true,
+                addErrorToBeDispatched: true,
+                decryptMessageToBeCalled: false,
             });
         });
 
@@ -209,18 +199,12 @@ describe('components/MessageDisplay', () => {
             const recipient = account1.address;
             const linkedAddress = null;
             const decryptAddress = account1.address;
-            const expectGetLinkedAddressToBeDispatched = false;
-            const expectAddErrorToBeDispatched = false;
-            const expectDecryptMessageToBeCalled = true;
 
             // Act + Assert:
-            await runUnlockAccountTest({
-                recipient,
-                linkedAddress,
-                decryptAddress,
-                expectGetLinkedAddressToBeDispatched,
-                expectAddErrorToBeDispatched,
-                expectDecryptMessageToBeCalled,
+            await runUnlockAccountTest(recipient, linkedAddress, decryptAddress, {
+                getLinkedAddressToBeDispatched: false,
+                addErrorToBeDispatched: false,
+                decryptMessageToBeCalled: true,
             });
         });
     });

--- a/__tests__/components/MessageInput.spec.ts
+++ b/__tests__/components/MessageInput.spec.ts
@@ -1,0 +1,68 @@
+/*
+ * (C) Symbol Contributors 2022
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and limitations under the License.
+ *
+ */
+import MessageInput from '@/components/MessageInput/MessageInput.vue';
+import { MessageInputTs } from '@/components/MessageInput/MessageInputTs';
+import { getComponent } from '@MOCKS/Components';
+
+const messageInputTs = new MessageInputTs();
+type Props = typeof messageInputTs.$props;
+
+describe('components/MessageInput', () => {
+    const StubComponent = {
+        template: '<div><slot /></div>',
+    };
+
+    const getMessageInputWrapper = (props: Props) => {
+        const stubs = {
+            ValidationProvider: StubComponent,
+            ErrorTooltip: StubComponent,
+        };
+
+        return getComponent(MessageInput, {}, {}, props, stubs);
+    };
+
+    test('render value', async () => {
+        // Arrange:
+        const expectedValue = 'message text';
+        const props = {
+            value: expectedValue,
+        };
+
+        // Act:
+        const wrapper = getMessageInputWrapper(props);
+        const textArea = wrapper.find('textarea');
+        const textAreaElement = textArea.element as HTMLInputElement;
+
+        // Assert:
+        expect(textAreaElement.value).toBe(expectedValue);
+    });
+
+    test('emit input event', async () => {
+        // Arrange:
+        const props = {};
+        const expectedInputText = 'new message';
+
+        // Act:
+        const wrapper = getMessageInputWrapper(props);
+        const textArea = wrapper.find('textarea');
+        const textAreaElement = textArea.element as HTMLInputElement;
+        textAreaElement.value = expectedInputText;
+        await textArea.trigger('input');
+
+        // Assert:
+        expect(wrapper.emitted()['input'][0][0]).toBe(expectedInputText);
+    });
+});

--- a/__tests__/components/MessageInput.spec.ts
+++ b/__tests__/components/MessageInput.spec.ts
@@ -17,8 +17,7 @@ import MessageInput from '@/components/MessageInput/MessageInput.vue';
 import { MessageInputTs } from '@/components/MessageInput/MessageInputTs';
 import { getComponent } from '@MOCKS/Components';
 
-const messageInputTs = new MessageInputTs();
-type Props = typeof messageInputTs.$props;
+type Props = InstanceType<typeof MessageInputTs>['$props'];
 
 describe('components/MessageInput', () => {
     const StubComponent = {


### PR DESCRIPTION
Added tests for:
  - `MessageDisplay`
  - `MessageInput`