### PR TITLE
[wallet/desktop] fix: multisig graph sorting issue

### DIFF
--- a/src/components/AccountMultisigGraph/AccountMultisigGraphTs.ts
+++ b/src/components/AccountMultisigGraph/AccountMultisigGraphTs.ts
@@ -67,7 +67,7 @@ export class AccountMultisigGraphTs extends Vue {
 
         const tree: TreeNode[] = [];
         const hashTable = {};
-        const sortedMultisigAccountGraphInfo = this.multisigAccountGraphInfo.sort((a, b) =>
+        const sortedMultisigAccountGraphInfo = [...this.multisigAccountGraphInfo].sort((a, b) =>
             a.accountAddress.plain() > b.accountAddress.plain() ? 1 : b.accountAddress.plain() > a.accountAddress.plain() ? -1 : 0,
         );
         sortedMultisigAccountGraphInfo.forEach((multisigAccountInfo) => {


### PR DESCRIPTION
## Problem

The `AccountMultisigGraph` `dataset` getter causes a side effect by mutating `multisigAccountGraphInfo` from `Account` state.

## Solution

Copy `multisigAccountGraphInfo` members to new array.