### PR TITLE
[wallet/desktop] fix: missing links in changelog

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -242,7 +242,7 @@ The changelog format is based on [Keep a Changelog](https://keepachangelog.com/e
 - Ledger with harvesting issues
 - Confirm buttons where dispalced
 
-## [1.0.1][1.0.1] - 29-Mar-2021
+## [1.0.1][v1.0.1] - 29-Mar-2021
 
 ### Milestone: [catapult-server@v1.0.0.0](https://github.com/symbol/catapult-server/releases/tag/v1.0.0.0)
 
@@ -251,20 +251,20 @@ The changelog format is based on [Keep a Changelog](https://keepachangelog.com/e
 - Changed transaction fee structure to align with network transaction fees. Reduced slow and average fee multipliers.
 - Increased HashLock duration and AggregatedBonded transaction deadline to 48 hours.
 
-## [1.0.0][1.0.0] - 15-Mar-2021
+## [1.0.0][v1.0.0] - 15-Mar-2021
 
 ### Milestone: [catapult-server@v1.0.0.0](https://github.com/symbol/catapult-server/releases/tag/v1.0.0.0)
 
 - Symbol mainnet launch release.
 
-## [0.15.1][0.15.1] - 13-Mar-2021
+## [0.15.1][v0.15.1] - 13-Mar-2021
 
 ### Milestone: [catapult-server@v1.0.0.0](https://github.com/symbol/catapult-server/releases/tag/v1.0.0.0)
 
 - Pre Symbol launch release.
 - Updated experimental Symbol mainnet node with final Opt In balances
 
-## [0.15.0][0.15.0] - 11-Mar-2021
+## [0.15.0][v0.15.0] - 11-Mar-2021
 
 ### Milestone: [catapult-server@v0.10.0.8](https://github.com/symbol/catapult-server/releases/tag/v0.10.0.8)
 
@@ -845,16 +845,34 @@ NOTE: We have known issues which have been logged into github and will look for 
 - Missing harvesting setup (account link & persistent delegation requests)
 - Some missing UI fixes for Symbol rebrand
 
-[v0.13.6]: https://github.com/symbol/desktop-wallet/releases/tag/v0.13.5...v0.13.6
-[v0.13.5]: https://github.com/symbol/desktop-wallet/releases/tag/v0.13.4...v0.13.5
-[v0.13.4]: https://github.com/symbol/desktop-wallet/releases/tag/v0.13.3...v0.13.4
-[v0.13.3]: https://github.com/symbol/desktop-wallet/releases/tag/v0.13.3...v0.13.3
-[v0.13.2]: https://github.com/symbol/desktop-wallet/releases/tag/v0.13.0...v0.13.2
-[v0.13.0]: https://github.com/symbol/desktop-wallet/releases/tag/v0.11.0...v0.13.0
-[v0.12.0]: https://github.com/symbol/desktop-wallet/releases/tag/v0.11.0...v0.12.0
-[v0.11.0]: https://github.com/symbol/desktop-wallet/releases/tag/v0.10.0...v0.11.0
-[v0.10.0]: https://github.com/symbol/desktop-wallet/releases/tag/v0.9.9...v0.10.0
-[v0.9.9]: https://github.com/symbol/desktop-wallet/releases/tag/v0.9.8-beta1...v0.9.9
+[v1.0.10]: https://github.com/symbol/desktop-wallet/releases/tag/v1.0.10
+[v1.0.9]: https://github.com/symbol/desktop-wallet/releases/tag/v1.0.9
+[v1.0.8]: https://github.com/symbol/desktop-wallet/releases/tag/v1.0.8
+[v1.0.7]: https://github.com/symbol/desktop-wallet/releases/tag/v1.0.7
+[v1.0.6]: https://github.com/symbol/desktop-wallet/releases/tag/v1.0.6
+[v1.0.5]: https://github.com/symbol/desktop-wallet/releases/tag/v1.0.5
+[v1.0.4]: https://github.com/symbol/desktop-wallet/releases/tag/v1.0.4
+[v1.0.3]: https://github.com/symbol/desktop-wallet/releases/tag/v1.0.3
+[v1.0.2]: https://github.com/symbol/desktop-wallet/releases/tag/v1.0.2
+[v1.0.1]: https://github.com/symbol/desktop-wallet/releases/tag/v1.0.1
+[v1.0.0]: https://github.com/symbol/desktop-wallet/releases/tag/v1.0.0
+[v1.0.0]: https://github.com/symbol/desktop-wallet/releases/tag/v1.0.0-beta.2
+[v0.15.1]: https://github.com/symbol/desktop-wallet/releases/tag/v0.15.1
+[v0.15.0]: https://github.com/symbol/desktop-wallet/releases/tag/v0.15.0
+[v0.14.1]: https://github.com/symbol/desktop-wallet/releases/tag/v0.14.1
+[v0.14.0]: https://github.com/symbol/desktop-wallet/releases/tag/v0.14.0
+[v0.13.8]: https://github.com/symbol/desktop-wallet/releases/tag/v0.13.8
+[v0.13.7]: https://github.com/symbol/desktop-wallet/releases/tag/v0.13.7
+[v0.13.6]: https://github.com/symbol/desktop-wallet/releases/tag/v0.13.6
+[v0.13.5]: https://github.com/symbol/desktop-wallet/releases/tag/v0.13.5
+[v0.13.4]: https://github.com/symbol/desktop-wallet/releases/tag/v0.13.4
+[v0.13.3]: https://github.com/symbol/desktop-wallet/releases/tag/v0.13.3
+[v0.13.2]: https://github.com/symbol/desktop-wallet/releases/tag/v0.13.2
+[v0.13.0]: https://github.com/symbol/desktop-wallet/releases/tag/v0.13.0
+[v0.12.0]: https://github.com/symbol/desktop-wallet/releases/tag/v0.12.0
+[v0.11.0]: https://github.com/symbol/desktop-wallet/releases/tag/v0.11.0
+[v0.10.0]: https://github.com/symbol/desktop-wallet/releases/tag/v0.10.0
+[v0.9.9]: https://github.com/symbol/desktop-wallet/releases/tag/v0.9.9
 [v0.9.8]: https://github.com/symbol/desktop-wallet/releases/tag/v0.9.8-beta1
 [v0.9.8-beta1]: https://github.com/symbol/desktop-wallet/compare/v0.9.7-beta1...v0.9.8-beta1
 [v0.9.7]: https://github.com/symbol/desktop-wallet/releases/tag/v0.9.7-beta1
@@ -869,6 +887,3 @@ NOTE: We have known issues which have been logged into github and will look for 
 [v0.9.5-beta2]: https://github.com/symbol/desktop-wallet/compare/v0.9.5-beta1...v0.9.5-beta2
 [v0.9.5-beta1]: https://github.com/symbol/desktop-wallet/compare/v0.9.4-beta...v0.9.5-beta1
 [v0.9.4-beta]: https://github.com/symbol/desktop-wallet/releases/tag/v0.9.4-beta
-
-[v1.0.5]: https://github.com/symbol/desktop-wallet/releases/tag/v1.0.5
-[v1.0.6]: https://github.com/symbol/desktop-wallet/releases/tag/v1.0.6

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
     "name": "symbol-desktop-wallet",
-    "version": "1.0.9",
+    "version": "1.0.10",
     "lockfileVersion": 2,
     "requires": true,
     "packages": {
         "": {
             "name": "symbol-desktop-wallet",
-            "version": "1.0.9",
+            "version": "1.0.10",
             "license": "Apache-2.0",
             "dependencies": {
                 "@fortawesome/fontawesome-svg-core": "^1.2.34",


### PR DESCRIPTION
- Added missing links for tags.
- Updated version in the `package.lock`