### PR TITLE
[wallet/desktop] build: notarization script apple team id param added

### DIFF
--- a/README.md
+++ b/README.md
@@ -71,6 +71,7 @@ npm run release
     export DESKTOP_APP_NOTARIZE=true
     export DESKTOP_APP_APPLE_ID=VALID_APPLE_DEV_ID
     export DESKTOP_APP_APPLE_PASSWORD=VALID_APPLE_DEV_PASSWORD
+    export DESKTOP_APP_APPLE_TEAM_ID=VALID_APPLE_TEAM_ID
     </pre>
 
     2.4 Enable auto discovery for code signing process to pick up the certificates from the keychain

--- a/scripts/notarize.js
+++ b/scripts/notarize.js
@@ -14,6 +14,9 @@ exports.default = async (context) => {
     } else if (process.env.DESKTOP_APP_APPLE_ID === undefined || process.env.DESKTOP_APP_APPLE_PASSWORD === undefined) {
         console.log('Skipping notarization because DESKTOP_APP_APPLE_ID or DESKTOP_APP_APPLE_PASSWORD env is not set.');
         return;
+    } else if (process.env.DESKTOP_APP_APPLE_TEAM_ID === undefined) {
+        console.log('Skipping notarization because DESKTOP_APP_APPLE_TEAM_ID env is not set.');
+        return;
     }
     const appName = context.packager.appInfo.productFilename;
     const appPath = `${appOutDir}/${appName}.app`;
@@ -25,5 +28,6 @@ exports.default = async (context) => {
         appPath: appPath,
         appleId: process.env.DESKTOP_APP_APPLE_ID,
         appleIdPassword: process.env.DESKTOP_APP_APPLE_PASSWORD,
+        ascProvider: process.env.DESKTOP_APP_APPLE_TEAM_ID,
     });
 };


### PR DESCRIPTION
## What was the issue?
Apple app notarization process has a new requirement, "Apple Team ID" param for the process. Because of this the notarization process was failing.

## What's the fix?
Added `DESKTOP_APP_APPLE_TEAM_ID ` parameter to the script. This is expected to be an environment parameter.