### PR TITLE
[wallet/desktop] fix: symbol-sdk transaction info fixes in tests

### DIFF
--- a/__mocks__/transactions.ts
+++ b/__mocks__/transactions.ts
@@ -25,6 +25,8 @@ export const transferTransaction = new TransferTransaction(
         UInt64.fromUint(108907),
         0,
         '',
+        UInt64.fromUint(1566230400),
+        100,
         '9661088F22C2DC72E76EE2B0F07BFC0D8E98EEE0CC8AE274362EDBB44F164F16',
         '9661088F22C2DC72E76EE2B0F07BFC0D8E98EEE0CC8AE274362EDBB44F164F16',
     ),

--- a/__tests__/components/TransactionDetails.spec.ts
+++ b/__tests__/components/TransactionDetails.spec.ts
@@ -43,6 +43,8 @@ describe('components/TransactionDetails', () => {
         'F4E954AEC49B99E2773A3B05273A31BE25683F852559CF11BDB61DE47195D82BC5DE9ED61C966F1668769CE782F8673E7F0C65099D967E3E806EE9AD27F3D70D';
     const mockDeadline = Deadline.createFromDTO('1');
     const mockMerkleComponentHash = '81E5E7AE49998802DABC816EC10158D3A7879702FF29084C2C992CD1289877A7';
+    const mockTimestamp = UInt64.fromUint(1);
+    const mockFeeMultiplier = 100;
 
     const dispatch = jest.fn();
 
@@ -57,7 +59,14 @@ describe('components/TransactionDetails', () => {
             message,
             mockSignature,
             PublicAccount.createFromPublicKey(currentSigner.publicKey, NetworkType.TEST_NET),
-            new TransactionInfo(UInt64.fromUint(2), 0, '1', '3A4B36EDFD3126D3911916497A9243336AE56B60B5CEB9410B4191D7338201CD'),
+            new TransactionInfo(
+                UInt64.fromUint(2),
+                0,
+                '1',
+                mockTimestamp,
+                mockFeeMultiplier,
+                '3A4B36EDFD3126D3911916497A9243336AE56B60B5CEB9410B4191D7338201CD',
+            ),
         );
     };
 
@@ -79,6 +88,8 @@ describe('components/TransactionDetails', () => {
                 UInt64.fromUint(2),
                 0,
                 '1',
+                mockTimestamp,
+                mockFeeMultiplier,
                 '3A4B36EDFD3126D3911916497A9243336AE56B60B5CEB9410B4191D7338201CD',
                 merkleComponentHash,
             ),

--- a/__tests__/components/TransactionList/TransactionList.spec.ts
+++ b/__tests__/components/TransactionList/TransactionList.spec.ts
@@ -22,13 +22,23 @@ describe('components/TransactionList', () => {
     const mockSignature =
         'F4E954AEC49B99E2773A3B05273A31BE25683F852559CF11BDB61DE47195D82BC5DE9ED61C966F1668769CE782F8673E7F0C65099D967E3E806EE9AD27F3D70D';
     const mockDeadline = Deadline.createFromDTO('1');
+    const mockTimestamp = UInt64.fromUint(1);
+    const mockFeeMultiplier = 100;
 
     const mockSignerAddress = PublicAccount.createFromPublicKey(WalletsModel1.publicKey, NetworkType.TEST_NET);
 
     const mockTransactionHash = '3A4B36EDFD3126D3911916497A9243336AE56B60B5CEB9410B4191D7338201CD';
     const mockMerkleComponentHash = '81E5E7AE49998802DABC816EC10158D3A7879702FF29084C2C992CD1289877A7';
 
-    const mockTransactionInfo = new TransactionInfo(UInt64.fromUint(2), 0, '1', mockTransactionHash, mockMerkleComponentHash);
+    const mockTransactionInfo = new TransactionInfo(
+        UInt64.fromUint(2),
+        0,
+        '1',
+        mockTimestamp,
+        mockFeeMultiplier,
+        mockTransactionHash,
+        mockMerkleComponentHash,
+    );
 
     const createMockTransferTransaction = (signerPublicAccount: PublicAccount = mockSignerAddress) => {
         return new TransferTransaction(
@@ -41,7 +51,7 @@ describe('components/TransactionList', () => {
             EmptyMessage,
             mockSignature,
             signerPublicAccount,
-            new TransactionInfo(UInt64.fromUint(2), 0, mockTransactionHash, mockMerkleComponentHash),
+            new TransactionInfo(UInt64.fromUint(2), 0, '1', mockTimestamp, mockFeeMultiplier, mockTransactionHash, mockMerkleComponentHash),
         );
     };
 

--- a/__tests__/components/TransactionList/TransactionRow.spec.ts
+++ b/__tests__/components/TransactionList/TransactionRow.spec.ts
@@ -56,6 +56,8 @@ describe('components/TransactionList/TransactionRow', () => {
         'F4E954AEC49B99E2773A3B05273A31BE25683F852559CF11BDB61DE47195D82BC5DE9ED61C966F1668769CE782F8673E7F0C65099D967E3E806EE9AD27F3D70D';
     const mockDeadline = Deadline.createFromDTO('1');
     const mockMerkleComponentHash = '81E5E7AE49998802DABC816EC10158D3A7879702FF29084C2C992CD1289877A7';
+    const mockTimestamp = UInt64.fromUint(1);
+    const mockFeeMultiplier = 100;
 
     const dispatch = jest.fn();
 
@@ -70,7 +72,14 @@ describe('components/TransactionList/TransactionRow', () => {
             message,
             mockSignature,
             PublicAccount.createFromPublicKey(currentSigner.publicKey, NetworkType.TEST_NET),
-            new TransactionInfo(UInt64.fromUint(2), 0, '1', '3A4B36EDFD3126D3911916497A9243336AE56B60B5CEB9410B4191D7338201CD'),
+            new TransactionInfo(
+                UInt64.fromUint(2),
+                0,
+                '1',
+                mockTimestamp,
+                mockFeeMultiplier,
+                '3A4B36EDFD3126D3911916497A9243336AE56B60B5CEB9410B4191D7338201CD',
+            ),
         );
     };
 
@@ -93,6 +102,8 @@ describe('components/TransactionList/TransactionRow', () => {
                 UInt64.fromUint(2),
                 0,
                 '1',
+                mockTimestamp,
+                mockFeeMultiplier,
                 '3A4B36EDFD3126D3911916497A9243336AE56B60B5CEB9410B4191D7338201CD',
                 merkleComponentHash,
             ),

--- a/__tests__/components/TransactionOptinPayoutDetails.spec.ts
+++ b/__tests__/components/TransactionOptinPayoutDetails.spec.ts
@@ -46,6 +46,8 @@ describe('components/TransactionDetails/TransactionOptinPayoutDetails', () => {
     const mockSignature =
         'F4E954AEC49B99E2773A3B05273A31BE25683F852559CF11BDB61DE47195D82BC5DE9ED61C966F1668769CE782F8673E7F0C65099D967E3E806EE9AD27F3D70D';
     const mockDeadline = Deadline.createFromDTO('1');
+    const mockTimestamp = UInt64.fromUint(1);
+    const mockFeeMultiplier = 100;
 
     const dispatch = jest.fn();
 
@@ -60,7 +62,14 @@ describe('components/TransactionDetails/TransactionOptinPayoutDetails', () => {
             message,
             mockSignature,
             PublicAccount.createFromPublicKey(currentSigner.publicKey, NetworkType.TEST_NET),
-            new TransactionInfo(UInt64.fromUint(2), 0, '1', '3A4B36EDFD3126D3911916497A9243336AE56B60B5CEB9410B4191D7338201CD'),
+            new TransactionInfo(
+                UInt64.fromUint(2),
+                0,
+                '1',
+                mockTimestamp,
+                mockFeeMultiplier,
+                '3A4B36EDFD3126D3911916497A9243336AE56B60B5CEB9410B4191D7338201CD',
+            ),
         );
     };
 
@@ -79,6 +88,8 @@ describe('components/TransactionDetails/TransactionOptinPayoutDetails', () => {
                 UInt64.fromUint(2),
                 0,
                 '1',
+                mockTimestamp,
+                mockFeeMultiplier,
                 '3A4B36EDFD3126D3911916497A9243336AE56B60B5CEB9410B4191D7338201CD',
                 '81E5E7AE49998802DABC816EC10158D3A7879702FF29084C2C992CD1289877A7',
             ),


### PR DESCRIPTION
## What was the issue?
After symbol-sdk@2.0.3 upgrade some of the unit tests began to fail due to the constructor signature change in TransactionInfo class.

## What's the fix?
Fixed the parameters need to be passed to TransactionInfo constructor.