### PR TITLE
[wallet/desktop] fix: video background player dependency fix, dependabot ignore

### DIFF
--- a/.github/dependabot.yaml
+++ b/.github/dependabot.yaml
@@ -11,3 +11,6 @@ updates:
     versioning-strategy: increase
     commit-message:
       prefix: '[dependency]'
+    ignore:
+      - dependency-name: "vue-responsive-video-background-player"
+        versions: ["2.x", "3.x"]

--- a/package-lock.json
+++ b/package-lock.json
@@ -43,7 +43,7 @@
                 "vue-pdf": "^4.2.0",
                 "vue-property-decorator": "^8.1.0",
                 "vue-qrcode-reader": "^3.0.0",
-                "vue-responsive-video-background-player": "^2.3.1",
+                "vue-responsive-video-background-player": "^1.3.5",
                 "vue-router": "^3.1.3",
                 "vue-rx": "^6.2.0",
                 "vue-toastification": "^1.7.11",
@@ -33362,9 +33362,9 @@
             "integrity": "sha512-W+y2EAI/BxS4Vlcca9scQv8ifeBFck56DRtSwWJ2H4Cw1GLNUYxiZxUHHkuzuI5JPW/cYtL1bPO5xPyEXx4LmQ=="
         },
         "node_modules/vue-responsive-video-background-player": {
-            "version": "2.3.1",
-            "resolved": "https://registry.npmjs.org/vue-responsive-video-background-player/-/vue-responsive-video-background-player-2.3.1.tgz",
-            "integrity": "sha512-9IdFfmHe1cY0PvTw51sYcSO5+gPJya5einLIoktVzBMALEC3yok36X/1+hDfbgihapRYxz3fmyv1o5M1u+0xEA=="
+            "version": "1.3.5",
+            "resolved": "https://registry.npmjs.org/vue-responsive-video-background-player/-/vue-responsive-video-background-player-1.3.5.tgz",
+            "integrity": "sha512-bctPoJg45nEZXK3AGYGdtzztLbUIbTrjptI0qUHj2iV+FRTRFTZvrAIJEejFcymJVoyNw7B3ZCChZ6mm/8zPHw=="
         },
         "node_modules/vue-router": {
             "version": "3.5.3",
@@ -61755,9 +61755,9 @@
             "integrity": "sha512-W+y2EAI/BxS4Vlcca9scQv8ifeBFck56DRtSwWJ2H4Cw1GLNUYxiZxUHHkuzuI5JPW/cYtL1bPO5xPyEXx4LmQ=="
         },
         "vue-responsive-video-background-player": {
-            "version": "2.3.1",
-            "resolved": "https://registry.npmjs.org/vue-responsive-video-background-player/-/vue-responsive-video-background-player-2.3.1.tgz",
-            "integrity": "sha512-9IdFfmHe1cY0PvTw51sYcSO5+gPJya5einLIoktVzBMALEC3yok36X/1+hDfbgihapRYxz3fmyv1o5M1u+0xEA=="
+            "version": "1.3.5",
+            "resolved": "https://registry.npmjs.org/vue-responsive-video-background-player/-/vue-responsive-video-background-player-1.3.5.tgz",
+            "integrity": "sha512-bctPoJg45nEZXK3AGYGdtzztLbUIbTrjptI0qUHj2iV+FRTRFTZvrAIJEejFcymJVoyNw7B3ZCChZ6mm/8zPHw=="
         },
         "vue-router": {
             "version": "3.5.3",

--- a/package.json
+++ b/package.json
@@ -76,7 +76,7 @@
         "vue-pdf": "^4.2.0",
         "vue-property-decorator": "^8.1.0",
         "vue-qrcode-reader": "^3.0.0",
-        "vue-responsive-video-background-player": "^2.3.1",
+        "vue-responsive-video-background-player": "^1.3.5",
         "vue-router": "^3.1.3",
         "vue-rx": "^6.2.0",
         "vue-toastification": "^1.7.11",


### PR DESCRIPTION
# What was the issue?
Dependabot has upgraded the `vue-responsive-video-background-player` version to `2.3.x` which is incompatible with `Vue 2.x`. It should be `1.x`.
# What's the fix?
Downgraded the version to `^1.3.5` and updated `dependabot.yaml` to ignore `vue-responsive-video-background-player v.2.x`

@Wayonb please review the `dependabot.yaml` changes, not 100% sure if that's the desired way we handle the ignores.