### PR TITLE
[wallet/desktop] fix: removed duplicate message property from en-US.json

### DIFF
--- a/src/language/en-US.json
+++ b/src/language/en-US.json
@@ -1059,7 +1059,6 @@
     "transaction_descriptor_16977": "Mosaic address restriction",
     "transaction_descriptor_16978": "Secret proof",
     "transaction_descriptor_17220": "Namespace metadata",
-    "transaction_descriptor_17229": "Mosaic supply revocation",
     "transaction_descriptor_17230": "Mosaic alias",
     "transaction_descriptor_17232": "Account operation restriction",
     "transaction_descriptor_harvesting": "Delegated Harvesting",


### PR DESCRIPTION
# What was the issue?
There is a duplicate message property in en-US.json. Reported https://github.com/symbol/desktop-wallet/issues/1961
The chosen name "Reclaim" is as this transaction type is presented in explorer.

# What's the fix?
Removed duplicate message property.