### PR TITLE
[wallet/desktop] task: update the symbol sdk dependency to 2.0.4

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -28,7 +28,7 @@
                 "request": "^2.88.0",
                 "rss-parser": "^3.7.3",
                 "rxjs": "^6.6.7",
-                "symbol-sdk": "^2.0.3",
+                "symbol-sdk": "^2.0.4",
                 "symbol-statistics-service-typescript-fetch-client": "1.1.3",
                 "trezor-connect": "^7.0.5",
                 "utf8": "^3.0.0",
@@ -32534,9 +32534,9 @@
             }
         },
         "node_modules/symbol-sdk": {
-            "version": "2.0.3",
-            "resolved": "https://registry.npmjs.org/symbol-sdk/-/symbol-sdk-2.0.3.tgz",
-            "integrity": "sha512-cTy1/E0yQCTMBrzCNCMMSVwgZdY0MTsw5A3vJCOyG9Dne03a/u8djEW5uB1H5c+mSul91FjP74Dey1Ay7uw8MQ==",
+            "version": "2.0.4",
+            "resolved": "https://registry.npmjs.org/symbol-sdk/-/symbol-sdk-2.0.4.tgz",
+            "integrity": "sha512-Z+54yxIld2WfboCpsIg3sZ4qtytfwA9cdXcADiZ3r7rFuEdAAEI5XT7cOqZhr52TOr5gtmzJOmzaeHeTBkm+gQ==",
             "dependencies": {
                 "@js-joda/core": "^3.2.0",
                 "catbuffer-typescript": "^1.0.2",
@@ -62131,9 +62131,9 @@
             }
         },
         "symbol-sdk": {
-            "version": "2.0.3",
-            "resolved": "https://registry.npmjs.org/symbol-sdk/-/symbol-sdk-2.0.3.tgz",
-            "integrity": "sha512-cTy1/E0yQCTMBrzCNCMMSVwgZdY0MTsw5A3vJCOyG9Dne03a/u8djEW5uB1H5c+mSul91FjP74Dey1Ay7uw8MQ==",
+            "version": "2.0.4",
+            "resolved": "https://registry.npmjs.org/symbol-sdk/-/symbol-sdk-2.0.4.tgz",
+            "integrity": "sha512-Z+54yxIld2WfboCpsIg3sZ4qtytfwA9cdXcADiZ3r7rFuEdAAEI5XT7cOqZhr52TOr5gtmzJOmzaeHeTBkm+gQ==",
             "requires": {
                 "@js-joda/core": "^3.2.0",
                 "catbuffer-typescript": "^1.0.2",

--- a/package.json
+++ b/package.json
@@ -62,7 +62,7 @@
         "request": "^2.88.0",
         "rss-parser": "^3.7.3",
         "rxjs": "^6.6.7",
-        "symbol-sdk": "^2.0.3",
+        "symbol-sdk": "^2.0.4",
         "symbol-statistics-service-typescript-fetch-client": "1.1.3",
         "trezor-connect": "^7.0.5",
         "utf8": "^3.0.0",


### PR DESCRIPTION
## What's the issue?

The desktop wallet uses version 2.0.3 of the symbol SDK. The latest one is 2.0.4

## What's the fix?

Update the symbol SDK to the latest version.