### PR TITLE
[wallet/desktop] fix: offline transaction - fill information about av…

### DIFF
--- a/__tests__/core/utils/NetworkConfigurationHelpers.spec.ts
+++ b/__tests__/core/utils/NetworkConfigurationHelpers.spec.ts
@@ -6,19 +6,27 @@ import { networkConfig } from '@/config';
 describe('core/utils/NetworkConfigurationHelpers', () => {
     describe('epochAdjustment()', () => {
         test('should return default value when no network configuration passed', () => {
+            // Arrange + Act:
             const epochAdjustment = NetworkConfigurationHelpers.epochAdjustment(undefined, 100);
+            // Assert:
             expect(epochAdjustment).toBe(100);
         });
 
         test('should return epoch adjustment for mainnet', () => {
+            // Arrange:
             const offlineNetworkConfiguration = OfflineNetworkProperties[NetworkType.MAIN_NET];
+            // Act:
             const epochAdjustment = NetworkConfigurationHelpers.epochAdjustment(offlineNetworkConfiguration, 100);
+            // Assert:
             expect(epochAdjustment).toBe(networkConfig[NetworkType.MAIN_NET].networkConfigurationDefaults.epochAdjustment);
         });
 
         test('should return epoch adjustment for testnet', () => {
+            // Arrange:
             const offlineNetworkConfiguration = OfflineNetworkProperties[NetworkType.TEST_NET];
+            // Act:
             const epochAdjustment = NetworkConfigurationHelpers.epochAdjustment(offlineNetworkConfiguration, 100);
+            // Assert:
             expect(epochAdjustment).toBe(networkConfig[NetworkType.TEST_NET].networkConfigurationDefaults.epochAdjustment);
         });
     });

--- a/__tests__/core/utils/NetworkConfigurationHelpers.spec.ts
+++ b/__tests__/core/utils/NetworkConfigurationHelpers.spec.ts
@@ -1,0 +1,25 @@
+import { NetworkType } from 'symbol-sdk';
+import { OfflineNetworkProperties } from '@/services/offline/MockModels';
+import { NetworkConfigurationHelpers } from '@/core/utils/NetworkConfigurationHelpers';
+import { networkConfig } from '@/config';
+
+describe('core/utils/NetworkConfigurationHelpers', () => {
+    describe('epochAdjustment()', () => {
+        test('should return default value when no network configuration passed', () => {
+            const epochAdjustment = NetworkConfigurationHelpers.epochAdjustment(undefined, 100);
+            expect(epochAdjustment).toBe(100);
+        });
+
+        test('should return epoch adjustment for mainnet', () => {
+            const offlineNetworkConfiguration = OfflineNetworkProperties[NetworkType.MAIN_NET];
+            const epochAdjustment = NetworkConfigurationHelpers.epochAdjustment(offlineNetworkConfiguration, 100);
+            expect(epochAdjustment).toBe(networkConfig[NetworkType.MAIN_NET].networkConfigurationDefaults.epochAdjustment);
+        });
+
+        test('should return epoch adjustment for testnet', () => {
+            const offlineNetworkConfiguration = OfflineNetworkProperties[NetworkType.TEST_NET];
+            const epochAdjustment = NetworkConfigurationHelpers.epochAdjustment(offlineNetworkConfiguration, 100);
+            expect(epochAdjustment).toBe(networkConfig[NetworkType.TEST_NET].networkConfigurationDefaults.epochAdjustment);
+        });
+    });
+});

--- a/src/services/offline/MockModels.ts
+++ b/src/services/offline/MockModels.ts
@@ -1,4 +1,6 @@
 import {
+    Address,
+    AccountType,
     AccountInfo,
     AccountNames,
     ChainInfo,
@@ -19,23 +21,21 @@ import {
     StorageInfo,
     TransactionFees,
     UInt64,
+    SupplementalPublicKeys,
+    AccountLinkNetworkProperties,
+    AggregateNetworkProperties,
+    HashLockNetworkProperties,
+    SecretLockNetworkProperties,
+    MetadataNetworkProperties,
+    MosaicNetworkProperties,
+    MultisigNetworkProperties,
+    NamespaceNetworkProperties,
+    AccountRestrictionNetworkProperties,
+    MosaicRestrictionNetworkProperties,
+    TransferNetworkProperties,
 } from 'symbol-sdk';
 import { NodeIdentityEqualityStrategy } from 'symbol-openapi-typescript-fetch-client';
-import { Address } from 'symbol-sdk';
-import { AccountType } from 'symbol-sdk';
-import { SupplementalPublicKeys } from 'symbol-sdk';
 import { networkConfig } from '@/config';
-import { AccountLinkNetworkProperties } from 'symbol-sdk/dist/src/model/network/AccountLinkNetworkProperties';
-import { AggregateNetworkProperties } from 'symbol-sdk/dist/src/model/network/AggregateNetworkProperties';
-import { HashLockNetworkProperties } from 'symbol-sdk/dist/src/model/network/HashLockNetworkProperties';
-import { SecretLockNetworkProperties } from 'symbol-sdk/dist/src/model/network/SecretLockNetworkProperties';
-import { MetadataNetworkProperties } from 'symbol-sdk/dist/src/model/network/MetadataNetworkProperties';
-import { MosaicNetworkProperties } from 'symbol-sdk/dist/src/model/network/MosaicNetworkProperties';
-import { MultisigNetworkProperties } from 'symbol-sdk/dist/src/model/network/MultisigNetworkProperties';
-import { NamespaceNetworkProperties } from 'symbol-sdk/dist/src/model/network/NamespaceNetworkProperties';
-import { AccountRestrictionNetworkProperties } from 'symbol-sdk/dist/src/model/network/AccountRestrictionNetworkProperties';
-import { MosaicRestrictionNetworkProperties } from 'symbol-sdk/dist/src/model/network/MosaicRestrictionNetworkProperties';
-import { TransferNetworkProperties } from 'symbol-sdk/dist/src/model/network/TransferNetworkProperties';
 
 export const OfflineUrl = 'http://mock:3000';
 
@@ -156,7 +156,7 @@ export const OfflineNetworkProperties = {
             new HashLockNetworkProperties("10'000'000", '2d'),
             new SecretLockNetworkProperties('365d', '0', '1024'),
             new MetadataNetworkProperties('1024'),
-            new MosaicNetworkProperties("1'000", '3650d', '6', 'NC733XE7DF46Q7QYLIIZBBSCJN2BEEP5FQ6PAYA', '500000'),
+            new MosaicNetworkProperties("1'000", '3650d', '6', 'NCVORTEX4XD5IQASZQEHDWUXT33XBOTBMKFDCLI', '500000'),
             new MultisigNetworkProperties('3', '25', '25'),
             new NamespaceNetworkProperties(
                 '64',
@@ -166,7 +166,7 @@ export const OfflineNetworkProperties = {
                 '1825d',
                 '30d',
                 'symbol, symbl, xym, xem, nem, user, account, org, com, biz, net, edu, mil, gov, info',
-                'NBDTBUD6R32ZYJWDEWLJM4YMOX3OOILHGDUMTSA',
+                'NCVORTEX4XD5IQASZQEHDWUXT33XBOTBMKFDCLI',
                 '2',
                 '100000',
             ),

--- a/src/services/offline/MockModels.ts
+++ b/src/services/offline/MockModels.ts
@@ -25,6 +25,17 @@ import { Address } from 'symbol-sdk';
 import { AccountType } from 'symbol-sdk';
 import { SupplementalPublicKeys } from 'symbol-sdk';
 import { networkConfig } from '@/config';
+import { AccountLinkNetworkProperties } from 'symbol-sdk/dist/src/model/network/AccountLinkNetworkProperties';
+import { AggregateNetworkProperties } from 'symbol-sdk/dist/src/model/network/AggregateNetworkProperties';
+import { HashLockNetworkProperties } from 'symbol-sdk/dist/src/model/network/HashLockNetworkProperties';
+import { SecretLockNetworkProperties } from 'symbol-sdk/dist/src/model/network/SecretLockNetworkProperties';
+import { MetadataNetworkProperties } from 'symbol-sdk/dist/src/model/network/MetadataNetworkProperties';
+import { MosaicNetworkProperties } from 'symbol-sdk/dist/src/model/network/MosaicNetworkProperties';
+import { MultisigNetworkProperties } from 'symbol-sdk/dist/src/model/network/MultisigNetworkProperties';
+import { NamespaceNetworkProperties } from 'symbol-sdk/dist/src/model/network/NamespaceNetworkProperties';
+import { AccountRestrictionNetworkProperties } from 'symbol-sdk/dist/src/model/network/AccountRestrictionNetworkProperties';
+import { MosaicRestrictionNetworkProperties } from 'symbol-sdk/dist/src/model/network/MosaicRestrictionNetworkProperties';
+import { TransferNetworkProperties } from 'symbol-sdk/dist/src/model/network/TransferNetworkProperties';
 
 export const OfflineUrl = 'http://mock:3000';
 
@@ -77,7 +88,30 @@ export const OfflineNetworkProperties = {
             'TDGY4DD2U4YQQGERFMDQYHPYS6M7LHIF6XUCJ4Q',
             "6'000",
         ),
-        new PluginProperties(),
+        new PluginProperties(
+            new AccountLinkNetworkProperties('to trigger plugin load'),
+            new AggregateNetworkProperties('100', '25', false, true, '48h'),
+            new HashLockNetworkProperties("10'000'000", '2d'),
+            new SecretLockNetworkProperties('365d', '0', '1024'),
+            new MetadataNetworkProperties('1024'),
+            new MosaicNetworkProperties("1'000", '3650d', '6', 'TA53AVLYMT5HCP5TJ23CGKGTUXQHNPBTJ4Z2LIQ', '500000'),
+            new MultisigNetworkProperties('3', '25', '25'),
+            new NamespaceNetworkProperties(
+                '64',
+                '100',
+                '3',
+                '30d',
+                '1825d',
+                '1d',
+                'symbol, symbl, xym, xem, nem, user, account, org, com, biz, net, edu, mil, gov, info',
+                'TDVFW6NZN3YI6O4ZRYZHGY73KADCW4HX6IDIKZI',
+                '2',
+                '100000',
+            ),
+            new AccountRestrictionNetworkProperties('100'),
+            new MosaicRestrictionNetworkProperties('20'),
+            new TransferNetworkProperties('1024'),
+        ),
     ),
     [NetworkType.MAIN_NET]: new NetworkConfiguration(
         new NetworkProperties(
@@ -116,7 +150,30 @@ export const OfflineNetworkProperties = {
             'NAMV77WU2EUFC6FBDFBQCDQARAGUTCRFDN7YLVA',
             "6'000",
         ),
-        new PluginProperties(),
+        new PluginProperties(
+            new AccountLinkNetworkProperties('to trigger plugin load'),
+            new AggregateNetworkProperties('100', '25', false, true, '48h'),
+            new HashLockNetworkProperties("10'000'000", '2d'),
+            new SecretLockNetworkProperties('365d', '0', '1024'),
+            new MetadataNetworkProperties('1024'),
+            new MosaicNetworkProperties("1'000", '3650d', '6', 'NC733XE7DF46Q7QYLIIZBBSCJN2BEEP5FQ6PAYA', '500000'),
+            new MultisigNetworkProperties('3', '25', '25'),
+            new NamespaceNetworkProperties(
+                '64',
+                '100',
+                '3',
+                '30d',
+                '1825d',
+                '30d',
+                'symbol, symbl, xym, xem, nem, user, account, org, com, biz, net, edu, mil, gov, info',
+                'NBDTBUD6R32ZYJWDEWLJM4YMOX3OOILHGDUMTSA',
+                '2',
+                '100000',
+            ),
+            new AccountRestrictionNetworkProperties('100'),
+            new MosaicRestrictionNetworkProperties('20'),
+            new TransferNetworkProperties('1024'),
+        ),
     ),
 };
 


### PR DESCRIPTION
## What's the issue?

The problem described in #1980
Method NetworkConfigurationHelpers.epochAdjustment (and others helper in this file) expected available plugins config to be present in network configuration. For offline transaction this has been not filled. Because of that wallet used epoch adjustment for the default network (testnet).

## What's the fix?
Fill in information about plugins for offline configuration