### PR TITLE
[wallet/desktop]: migrate to node watch service

### DIFF
--- a/__tests__/services/NodeWatchService.spec.ts
+++ b/__tests__/services/NodeWatchService.spec.ts
@@ -43,16 +43,16 @@ describe('services/NodeWatchService', () => {
             }
         });
 
-        const runAssertNodes = async (results, { onlySSL, limit, order }) => {
+        const runAssertNodes = async (results, { limit, order }) => {
             // Assert:
             expect(mockFetch).toHaveBeenNthCalledWith(
                 1,
-                `${baseUrl}` + `/api/symbol/nodes/api?only_ssl=${onlySSL}&limit=${limit}${order ? `&order=${order}` : ''}`,
+                `${baseUrl}` + `/api/symbol/nodes/api?only_ssl=true&limit=${limit}${order ? `&order=${order}` : ''}`,
                 {},
             );
             expect(mockFetch).toHaveBeenNthCalledWith(
                 2,
-                `${baseUrl}` + `/api/symbol/nodes/peer?only_ssl=${onlySSL}&limit=${limit}${order ? `&order=${order}` : ''}`,
+                `${baseUrl}` + `/api/symbol/nodes/peer?only_ssl=true&limit=${limit}${order ? `&order=${order}` : ''}`,
                 {},
             );
             expect(results).toStrictEqual([
@@ -75,7 +75,6 @@ describe('services/NodeWatchService', () => {
 
             // Assert:
             runAssertNodes(nodes, {
-                onlySSL: true,
                 limit: 0,
                 order: null,
             });
@@ -83,11 +82,10 @@ describe('services/NodeWatchService', () => {
 
         test('fetches nodes with parameters', async () => {
             // Act:
-            const nodes = await nodeService.getNodes(false, 10, 'random');
+            const nodes = await nodeService.getNodes(10, 'random');
 
             // Assert:
             runAssertNodes(nodes, {
-                onlySSL: false,
                 limit: 10,
                 order: 'random',
             });

--- a/__tests__/services/NodeWatchService.spec.ts
+++ b/__tests__/services/NodeWatchService.spec.ts
@@ -1,0 +1,156 @@
+import { NodeWatchService } from '@/services/NodeWatchService';
+import { networkConfig } from '@/config';
+
+describe('services/NodeWatchService', () => {
+    const mockFetch = jest.fn();
+    (global as any).fetch = mockFetch;
+
+    const createMockNodeResponse = () => ({
+        endpoint: 'http://example.com:3000',
+        friendlyName: 'Node1',
+        mainPublicKey: 'mainKey1',
+        nodePublicKey: 'nodeKey1',
+        isSslEnabled: true,
+        isHealthy: true,
+        restVersion: '1.0.0',
+    });
+
+    const mockNetworkType = 104;
+    const baseUrl = networkConfig[mockNetworkType].nodeWatchServiceUrl;
+    let nodeService;
+
+    beforeEach(() => {
+        jest.clearAllMocks();
+        nodeService = new NodeWatchService(mockNetworkType);
+    });
+
+    describe('getNodes()', () => {
+        // Arrange:`
+        mockFetch.mockImplementation((url) => {
+            if (url.includes('/api/symbol/nodes/api')) {
+                return Promise.resolve({
+                    ok: true,
+                    status: 200,
+                    json: () => Promise.resolve([createMockNodeResponse()]),
+                });
+            }
+            if (url.includes('/api/symbol/nodes/peer')) {
+                return Promise.resolve({
+                    ok: true,
+                    status: 200,
+                    json: () => Promise.resolve([]),
+                });
+            }
+        });
+
+        const runAssertNodes = async (results, { onlySSL, limit, order }) => {
+            // Assert:
+            expect(mockFetch).toHaveBeenNthCalledWith(
+                1,
+                `${baseUrl}` + `/api/symbol/nodes/api?only_ssl=${onlySSL}&limit=${limit}${order ? `&order=${order}` : ''}`,
+                {},
+            );
+            expect(mockFetch).toHaveBeenNthCalledWith(
+                2,
+                `${baseUrl}` + `/api/symbol/nodes/peer?only_ssl=${onlySSL}&limit=${limit}${order ? `&order=${order}` : ''}`,
+                {},
+            );
+            expect(results).toStrictEqual([
+                {
+                    ...createMockNodeResponse(),
+                    endpoint: 'https://example.com:3001',
+                    wsUrl: 'wss://example.com:3001/ws',
+                },
+            ]);
+        };
+
+        test('fetches nodes with default parameters', async () => {
+            // Act:
+            const nodes = await nodeService.getNodes();
+
+            // Assert:
+            runAssertNodes(nodes, {
+                onlySSL: true,
+                limit: 0,
+                order: null,
+            });
+        });
+
+        test('fetches nodes with parameters', async () => {
+            // Act:
+            const nodes = await nodeService.getNodes(false, 10, 'random');
+
+            // Assert:
+            runAssertNodes(nodes, {
+                onlySSL: false,
+                limit: 10,
+                order: 'random',
+            });
+        });
+    });
+
+    const runGetNodeByMethodTest = async (method, paramValue, expectedUrl) => {
+        // Arrange:
+        const mockResponse = createMockNodeResponse();
+        mockFetch.mockResolvedValueOnce({
+            ok: true,
+            status: 200,
+            json: () => Promise.resolve(mockResponse),
+        });
+
+        // Act:
+        const node = await nodeService[method](paramValue);
+
+        // Assert:
+        expect(mockFetch).toHaveBeenCalledWith(baseUrl + expectedUrl, {});
+        expect(node).toEqual({
+            ...mockResponse,
+            endpoint: 'https://example.com:3001',
+            wsUrl: 'wss://example.com:3001/ws',
+        });
+    };
+
+    const runThrowErrorNodeNotFoundTest = async (method, paramValue, expectedUrl) => {
+        // Arrange:
+        mockFetch.mockResolvedValueOnce({
+            ok: false,
+            status: 404,
+            statusText: 'Not Found',
+        });
+
+        // Act:
+        const node = await nodeService[method](paramValue);
+
+        // Assert:
+        expect(mockFetch).toHaveBeenCalledWith(baseUrl + expectedUrl, {});
+        expect(node).toBeUndefined();
+    };
+
+    describe('getNodeByMainPublicKey()', () => {
+        test('returns node info by main public key', async () => {
+            await runGetNodeByMethodTest('getNodeByMainPublicKey', 'mainKey1', '/api/symbol/nodes/mainPublicKey/mainKey1');
+        });
+
+        test('returns undefined when node not found', async () => {
+            await runThrowErrorNodeNotFoundTest(
+                'getNodeByMainPublicKey',
+                'nonExistentKey',
+                '/api/symbol/nodes/mainPublicKey/nonExistentKey',
+            );
+        });
+    });
+
+    describe('getNodeByNodePublicKey()', () => {
+        test('returns node info by node public key', async () => {
+            await runGetNodeByMethodTest('getNodeByNodePublicKey', 'nodeKey1', '/api/symbol/nodes/nodePublicKey/nodeKey1');
+        });
+
+        test('returns undefined when node not found', async () => {
+            await runThrowErrorNodeNotFoundTest(
+                'getNodeByNodePublicKey',
+                'nonExistentKey',
+                '/api/symbol/nodes/nodePublicKey/nonExistentKey',
+            );
+        });
+    });
+});

--- a/__tests__/services/NodeWatchService.spec.ts
+++ b/__tests__/services/NodeWatchService.spec.ts
@@ -7,7 +7,7 @@ describe('services/NodeWatchService', () => {
 
     const createMockNodeResponse = () => ({
         endpoint: 'http://example.com:3000',
-        friendlyName: 'Node1',
+        name: 'Node1',
         mainPublicKey: 'mainKey1',
         nodePublicKey: 'nodeKey1',
         isSslEnabled: true,
@@ -57,7 +57,12 @@ describe('services/NodeWatchService', () => {
             );
             expect(results).toStrictEqual([
                 {
-                    ...createMockNodeResponse(),
+                    friendlyName: 'Node1',
+                    mainPublicKey: 'mainKey1',
+                    nodePublicKey: 'nodeKey1',
+                    isSslEnabled: true,
+                    isHealthy: true,
+                    restVersion: '1.0.0',
                     endpoint: 'https://example.com:3001',
                     wsUrl: 'wss://example.com:3001/ws',
                 },
@@ -104,7 +109,12 @@ describe('services/NodeWatchService', () => {
         // Assert:
         expect(mockFetch).toHaveBeenCalledWith(baseUrl + expectedUrl, {});
         expect(node).toEqual({
-            ...mockResponse,
+            friendlyName: 'Node1',
+            mainPublicKey: 'mainKey1',
+            nodePublicKey: 'nodeKey1',
+            isSslEnabled: true,
+            isHealthy: true,
+            restVersion: '1.0.0',
             endpoint: 'https://example.com:3001',
             wsUrl: 'wss://example.com:3001/ws',
         });

--- a/__tests__/services/NodeWatchService.spec.ts
+++ b/__tests__/services/NodeWatchService.spec.ts
@@ -6,7 +6,7 @@ describe('services/NodeWatchService', () => {
     (global as any).fetch = mockFetch;
 
     const createMockNodeResponse = () => ({
-        endpoint: 'http://example.com:3000',
+        endpoint: 'https://example.com:3001',
         name: 'Node1',
         mainPublicKey: 'mainKey1',
         nodePublicKey: 'nodeKey1',

--- a/__tests__/views/forms/FormPersistentDelegationRequestTransaction.spec.ts
+++ b/__tests__/views/forms/FormPersistentDelegationRequestTransaction.spec.ts
@@ -40,16 +40,32 @@ import flushPromises from 'flush-promises';
 import WS from 'jest-websocket-mock';
 import { setupServer } from 'msw/node';
 import { AccountInfo, Address, Convert, KeyPair } from 'symbol-sdk';
+import { NodeWatchService } from '@/services/NodeWatchService';
 
 // mock local storage
 jest.mock('@/core/database/backends/LocalStorageBackend', () => ({
     LocalStorageBackend: jest.requireActual('@/core/database/backends/ObjectStorageBackend').ObjectStorageBackend,
 }));
 
+// Mock NodeWatchService responses
+const nodeResponse = {
+    endpoint: 'https://example.com:3001',
+    friendlyName: 'Node1',
+    mainPublicKey: '0'.repeat(64),
+    nodePublicKey: '0'.repeat(64),
+    isSslEnabled: true,
+    isHealthy: true,
+    restVersion: '1.0.0',
+    wsUrl: 'wss://example.com:3001/ws',
+};
+jest.spyOn(NodeWatchService.prototype, 'getNodes').mockReturnValue(Promise.resolve([nodeResponse]));
+jest.spyOn(NodeWatchService.prototype, 'getNodeByMainPublicKey').mockReturnValue(Promise.resolve(nodeResponse));
+jest.spyOn(NodeWatchService.prototype, 'getNodeByNodePublicKey').mockReturnValue(Promise.resolve(nodeResponse));
+
 // mock http server with base responses denoted by * which are basic responses for the accounts __mock__/Accounts.ts
 const httpServer = setupServer(...getHandlers(responses['*']));
 // mock websocket server
-const websocketServer = new WS('wss://001-joey-dual.symboltest.net:3001/ws', { jsonProtocol: true });
+const websocketServer = new WS('wss://example.com:3001/ws', { jsonProtocol: true });
 websocketServer.on('connection', (socket) => {
     console.log('Websocket client connected!');
     socket.send('{"uid":"FAKE_UID"}');
@@ -200,7 +216,7 @@ describe('views/forms/FormPersistentDelegationRequestTransaction', () => {
 
             // Act:
             const input = await screen.findByPlaceholderText(i18n.t('form_label_network_node_url').toString());
-            await userEvent.type(input, 'https://001-joey-dual.symboltest.net:3001');
+            await userEvent.type(input, 'https://example.com:3001');
             await TestUIHelpers.selectMaxFee(selectedMaxFee);
             const button = await screen.findByRole('button', { name: i18n.t('start_harvesting').toString() });
             userEvent.click(button);
@@ -418,7 +434,7 @@ describe('views/forms/FormPersistentDelegationRequestTransaction', () => {
 
         // Act:
         const input = await screen.findByPlaceholderText(i18n.t('form_label_network_node_url').toString());
-        await userEvent.type(input, 'https://001-joey-dual.symboltest.net:3001');
+        await userEvent.type(input, 'https://example.com:3001');
         const keyLinksTab = await screen.findByText(i18n.t('tab_harvesting_key_links').toString());
         userEvent.click(keyLinksTab);
 

--- a/__tests__/views/forms/FormTransferTransaction.spec.ts
+++ b/__tests__/views/forms/FormTransferTransaction.spec.ts
@@ -17,16 +17,26 @@ import { fireEvent, screen, waitFor } from '@testing-library/vue';
 import flushPromises from 'flush-promises';
 import WS from 'jest-websocket-mock';
 import { setupServer } from 'msw/node';
+import { NodeService } from '@/services/NodeService';
+import { NodeModel } from '@/core/database/entities/NodeModel';
+import { NetworkType } from 'symbol-sdk';
 
 // mock local storage
 jest.mock('@/core/database/backends/LocalStorageBackend', () => ({
     LocalStorageBackend: jest.requireActual('@/core/database/backends/ObjectStorageBackend').ObjectStorageBackend,
 }));
 
+// mock the NodeService to control the nodes returned
+jest.spyOn(NodeService.prototype, 'getNodesFromNodeWatchService').mockReturnValue(
+    Promise.resolve([
+        new NodeModel('https://example.com:3001', 'Node1', true, NetworkType.TEST_NET, 'mainKey1', 'nodeKey1', 'wss://example.com:3001/ws'),
+    ]),
+);
+
 // mock http server with base responses denoted by * which are basic responses for the accounts __mock__/Accounts.ts
 const httpServer = setupServer(...getHandlers(responses['*']));
 // mock websocket server
-const websocketServer = new WS('wss://001-joey-dual.symboltest.net:3001/ws', { jsonProtocol: true });
+const websocketServer = new WS('wss://example.com:3001/ws', { jsonProtocol: true });
 websocketServer.on('connection', (socket) => {
     console.log('Websocket client connected!');
     socket.send('{"uid":"FAKE_UID"}');

--- a/package-lock.json
+++ b/package-lock.json
@@ -29,7 +29,6 @@
                 "rss-parser": "^3.13.0",
                 "rxjs": "^6.6.7",
                 "symbol-sdk": "^2.0.4",
-                "symbol-statistics-service-typescript-fetch-client": "1.1.3",
                 "trezor-connect": "^7.0.5",
                 "utf8": "^3.0.0",
                 "vee-validate": "^3.2.3",
@@ -33864,11 +33863,6 @@
                 "webidl-conversions": "^3.0.0"
             }
         },
-        "node_modules/symbol-statistics-service-typescript-fetch-client": {
-            "version": "1.1.3",
-            "resolved": "https://registry.npmjs.org/symbol-statistics-service-typescript-fetch-client/-/symbol-statistics-service-typescript-fetch-client-1.1.3.tgz",
-            "integrity": "sha512-RRGRp8gVkV2muUgRJCgEkoSt1ietWmvqyYppz2wohtNyAAmPDeWdQDDt3fp3mw6ZmviHr9ZpehaG2J0gxHlMWg=="
-        },
         "node_modules/symbol-tree": {
             "version": "3.2.4",
             "resolved": "https://registry.npmjs.org/symbol-tree/-/symbol-tree-3.2.4.tgz",
@@ -64547,11 +64541,6 @@
                     }
                 }
             }
-        },
-        "symbol-statistics-service-typescript-fetch-client": {
-            "version": "1.1.3",
-            "resolved": "https://registry.npmjs.org/symbol-statistics-service-typescript-fetch-client/-/symbol-statistics-service-typescript-fetch-client-1.1.3.tgz",
-            "integrity": "sha512-RRGRp8gVkV2muUgRJCgEkoSt1ietWmvqyYppz2wohtNyAAmPDeWdQDDt3fp3mw6ZmviHr9ZpehaG2J0gxHlMWg=="
         },
         "symbol-tree": {
             "version": "3.2.4",

--- a/package.json
+++ b/package.json
@@ -63,7 +63,6 @@
         "rss-parser": "^3.13.0",
         "rxjs": "^6.6.7",
         "symbol-sdk": "^2.0.4",
-        "symbol-statistics-service-typescript-fetch-client": "1.1.3",
         "trezor-connect": "^7.0.5",
         "utf8": "^3.0.0",
         "vee-validate": "^3.2.3",

--- a/src/components/NetworkNodeSelector/NetworkNodeSelectorTs.ts
+++ b/src/components/NetworkNodeSelector/NetworkNodeSelectorTs.ts
@@ -121,7 +121,7 @@ export class NetworkNodeSelectorTs extends Vue {
     }
 
     protected async fetchAndSetNodeModel(networkType: NetworkType, nodePublicKey: string) {
-        const nodeModel = await new NodeService().getNodeFromStatisticServiceByNodePublicKey(networkType, nodePublicKey);
+        const nodeModel = await new NodeService().getNodeFromNodeWatchServiceByNodePublicKey(networkType, nodePublicKey);
         if (nodeModel) {
             this.formNodeUrl = nodeModel.url;
             Vue.set(this, 'showInputPublicKey', false);

--- a/src/config/NetworkConfig.ts
+++ b/src/config/NetworkConfig.ts
@@ -47,13 +47,13 @@ export interface NetworkConfig {
     defaultNetworkType: number;
     explorerUrl: string;
     networkConfigurationDefaults: NetworkConfigurationDefaults;
-    statisticServiceUrl: string;
+    nodeWatchServiceUrl: string;
 }
 
 export const defaultTestnetNetworkConfig: NetworkConfig = {
     explorerUrl: 'https://testnet.symbol.fyi/',
     faucetUrl: 'https://testnet.symbol.tools/',
-    statisticServiceUrl: 'https://testnet.symbol.services',
+    nodeWatchServiceUrl: 'https://nodewatch.symbol.tools/testnet',
     defaultNetworkType: 152,
     networkConfigurationDefaults: {
         maxMosaicDivisibility: 6,
@@ -81,7 +81,7 @@ export const defaultTestnetNetworkConfig: NetworkConfig = {
 export const defaultMainnetNetworkConfig: NetworkConfig = {
     explorerUrl: 'https://symbol.fyi/',
     faucetUrl: 'https://faucet.mainnet.symboldev.network/',
-    statisticServiceUrl: 'https://symbol.services',
+    nodeWatchServiceUrl: 'https://nodewatch.symbol.tools',
     defaultNetworkType: 104,
     networkConfigurationDefaults: {
         maxMosaicDivisibility: 6,

--- a/src/services/NodeService.ts
+++ b/src/services/NodeService.ts
@@ -73,16 +73,11 @@ export class NodeService {
             .then((val) => (statisticsNodes && statisticsNodes.length ? _.uniqBy(val.concat([...statisticsNodes]), 'url') : val));
     }
 
-    public async getNodesFromNodeWatchService(
-        networkType: NetworkType,
-        limit = 30,
-        sslOnly = true,
-        isOffline?: boolean,
-    ): Promise<NodeModel[]> {
+    public async getNodesFromNodeWatchService(networkType: NetworkType, limit = 30, isOffline?: boolean): Promise<NodeModel[]> {
         if (!isOffline && navigator.onLine) {
             try {
                 const nodeWatchService = new NodeWatchService(networkType);
-                let nodeInfos = await nodeWatchService.getNodes(sslOnly, limit, 'random');
+                let nodeInfos = await nodeWatchService.getNodes(limit, 'random');
 
                 if (!nodeInfos) {
                     return undefined;

--- a/src/services/NodeService.ts
+++ b/src/services/NodeService.ts
@@ -134,8 +134,8 @@ export class NodeService {
 
             return this.getNodeModelByMethod(
                 networkType,
-                async (pKey) => {
-                    return await nodeWatchService.getNodeByMainPublicKey(pKey);
+                async (publicKey) => {
+                    return await nodeWatchService.getNodeByMainPublicKey(publicKey);
                 },
                 publicKey,
             );
@@ -153,8 +153,8 @@ export class NodeService {
 
             return this.getNodeModelByMethod(
                 networkType,
-                async (npKey) => {
-                    return await nodeWatchService.getNodeByNodePublicKey(npKey);
+                async (publicKey) => {
+                    return await nodeWatchService.getNodeByNodePublicKey(publicKey);
                 },
                 nodePublicKey,
             );

--- a/src/services/NodeService.ts
+++ b/src/services/NodeService.ts
@@ -19,11 +19,10 @@ import { ObservableHelpers } from '@/core/utils/ObservableHelpers';
 import { map, tap } from 'rxjs/operators';
 import { NodeModel } from '@/core/database/entities/NodeModel';
 import * as _ from 'lodash';
-import { appConfig, networkConfig } from '@/config';
+import { appConfig } from '@/config';
 import { NodeModelStorage } from '@/core/database/storage/NodeModelStorage';
 import { ProfileModel } from '@/core/database/entities/ProfileModel';
-import fetch from 'node-fetch';
-import { Configuration, NodeApi, NodeListFilter, NodeInfo as NodeApiNodeInfo } from 'symbol-statistics-service-typescript-fetch-client';
+import { NodeWatchService, NodeApiNodeInfo } from '@/services/NodeWatchService';
 
 /**
  * The service in charge of loading and caching anything related to Node and Peers from Rest.
@@ -47,7 +46,7 @@ export class NodeService {
         isOffline?: boolean,
     ): Promise<NodeModel[]> {
         const storedNodes = this.getKnownNodesOnly(profile);
-        const statisticsNodes = !isOffline ? await this.getNodesFromStatisticService(profile.networkType) : [];
+        const statisticsNodes = !isOffline ? await this.getNodesFromNodeWatchService(profile.networkType) : [];
         const nodeRepository = repositoryFactory.createNodeRepository();
         const nodeWsUrl =
             storedNodes.find((n) => n.url === repositoryFactoryUrl)?.wsUrl ||
@@ -74,38 +73,24 @@ export class NodeService {
             .then((val) => (statisticsNodes && statisticsNodes.length ? _.uniqBy(val.concat([...statisticsNodes]), 'url') : val));
     }
 
-    public async getNodesFromStatisticService(
+    public async getNodesFromNodeWatchService(
         networkType: NetworkType,
         limit = 30,
         sslOnly = true,
         isOffline?: boolean,
     ): Promise<NodeModel[]> {
-        const nodeSearchCriteria = {
-            nodeFilter: NodeListFilter.Suggested,
-            limit,
-            ...(sslOnly ? { ssl: sslOnly } : {}),
-        };
         if (!isOffline && navigator.onLine) {
             try {
-                let nodeInfos = await this.createStatisticServiceRestClient(networkConfig[networkType].statisticServiceUrl).getNodes(
-                    nodeSearchCriteria.nodeFilter,
-                    nodeSearchCriteria.limit,
-                    nodeSearchCriteria.ssl,
-                );
+                const nodeWatchService = new NodeWatchService(networkType);
+                let nodeInfos = await nodeWatchService.getNodes(sslOnly, limit, 'random');
+
                 if (!nodeInfos) {
                     return undefined;
                 }
-                nodeInfos = nodeInfos.filter((n) => n.apiStatus?.webSocket?.isAvailable);
+                nodeInfos = nodeInfos.filter((n) => n.endpoint !== '' && n.isSslEnabled && n.isHealthy);
+
                 return nodeInfos.map((n) =>
-                    this.createNodeModel(
-                        n.apiStatus?.restGatewayUrl,
-                        networkType,
-                        n.friendlyName,
-                        true,
-                        n.publicKey,
-                        n.apiStatus?.nodePublicKey,
-                        n.apiStatus.webSocket.url,
-                    ),
+                    this.createNodeModel(n.endpoint, networkType, n.friendlyName, true, n.mainPublicKey, n.nodePublicKey, n.wsUrl),
                 );
             } catch (error) {
                 // proceed to return
@@ -123,13 +108,13 @@ export class NodeService {
             const nodeInfo = await nodeGetter(paramValue);
             if (nodeInfo) {
                 return this.createNodeModel(
-                    nodeInfo.apiStatus?.restGatewayUrl,
+                    nodeInfo.endpoint,
                     networkType,
                     nodeInfo.friendlyName,
                     true,
-                    nodeInfo.publicKey,
-                    nodeInfo.apiStatus?.nodePublicKey,
-                    nodeInfo.apiStatus?.webSocket?.url,
+                    nodeInfo.mainPublicKey,
+                    nodeInfo.nodePublicKey,
+                    nodeInfo.wsUrl,
                 );
             }
         } catch (error) {
@@ -139,31 +124,38 @@ export class NodeService {
         return undefined;
     }
 
-    public async getNodeFromStatisticServiceByPublicKey(
+    public async getNodeFromNodeWatchServiceByMainPublicKey(
         networkType: NetworkType,
         publicKey: string,
         isOffline?: boolean,
     ): Promise<NodeModel> {
         if (!isOffline && navigator.onLine && publicKey) {
+            const nodeWatchService = new NodeWatchService(networkType);
+
             return this.getNodeModelByMethod(
                 networkType,
-                (pKey) => this.createStatisticServiceRestClient(networkConfig[networkType].statisticServiceUrl).getNode(pKey),
+                async (pKey) => {
+                    return await nodeWatchService.getNodeByMainPublicKey(pKey);
+                },
                 publicKey,
             );
         }
         return undefined;
     }
 
-    public async getNodeFromStatisticServiceByNodePublicKey(
+    public async getNodeFromNodeWatchServiceByNodePublicKey(
         networkType: NetworkType,
         nodePublicKey: string,
         isOffline?: boolean,
     ): Promise<NodeModel> {
         if (!isOffline && navigator.onLine && nodePublicKey) {
+            const nodeWatchService = new NodeWatchService(networkType);
+
             return this.getNodeModelByMethod(
                 networkType,
-                (npKey) =>
-                    this.createStatisticServiceRestClient(networkConfig[networkType].statisticServiceUrl).getNodeByNodePublicKey(npKey),
+                async (npKey) => {
+                    return await nodeWatchService.getNodeByNodePublicKey(npKey);
+                },
                 nodePublicKey,
             );
         }
@@ -175,11 +167,11 @@ export class NodeService {
         networkType: NetworkType,
         friendlyName: string | undefined = undefined,
         isDefault: boolean | undefined = undefined,
-        publicKey?: string,
+        mainPublicKey?: string,
         nodePublicKey?: string,
         wsUrl?: string,
     ): NodeModel {
-        return new NodeModel(url, friendlyName, isDefault, networkType, publicKey, nodePublicKey, wsUrl);
+        return new NodeModel(url, friendlyName, isDefault, networkType, mainPublicKey, nodePublicKey, wsUrl);
     }
 
     public loadNodes(profile: ProfileModel): NodeModel[] {
@@ -197,14 +189,6 @@ export class NodeService {
         this.storage.remove();
     }
 
-    public createStatisticServiceRestClient(statisticsServiceUrl: string): NodeApi {
-        return new NodeApi(
-            new Configuration({
-                fetchApi: fetch as any,
-                basePath: statisticsServiceUrl,
-            }),
-        );
-    }
     /**
      * Creates offline mock node model for offline transaction
      * @param {networkType} NetworkType

--- a/src/services/NodeWatchService.ts
+++ b/src/services/NodeWatchService.ts
@@ -35,8 +35,8 @@ export class NodeWatchService {
         };
     }
 
-    async getNodes(onlySSL = true, limit = 0, order = null): Promise<NodeApiNodeInfo[]> {
-        const params = `only_ssl=${onlySSL}&limit=${limit}${order ? `&order=${order}` : ''}`;
+    async getNodes(limit = 0, order = null): Promise<NodeApiNodeInfo[]> {
+        const params = `only_ssl=true&limit=${limit}${order ? `&order=${order}` : ''}`;
 
         const [apiNodesResponse, peerNodesResponse] = await Promise.all([
             this.get(`/api/symbol/nodes/api?${params}`),

--- a/src/services/NodeWatchService.ts
+++ b/src/services/NodeWatchService.ts
@@ -1,0 +1,74 @@
+import { networkConfig } from '@/config';
+import { NetworkType } from 'symbol-sdk';
+
+export interface NodeApiNodeInfo {
+    endpoint: string;
+    friendlyName: string;
+    mainPublicKey: string;
+    nodePublicKey: string;
+    isSslEnabled: boolean;
+    isHealthy: boolean;
+    restVersion: string;
+    wsUrl: string;
+}
+
+export class NodeWatchService {
+    private readonly url: string;
+
+    constructor(networkType: NetworkType) {
+        this.url = networkConfig[networkType].nodeWatchServiceUrl;
+    }
+
+    private mapResponseToNodeApiInfo(response: any): NodeApiNodeInfo {
+        const endpoint = response.endpoint.replace('http', 'https').replace('3000', '3001');
+        const wsUrl = endpoint.replace('https', 'wss') + '/ws';
+
+        return {
+            endpoint,
+            friendlyName: response.friendlyName,
+            mainPublicKey: response.mainPublicKey,
+            nodePublicKey: response.nodePublicKey,
+            isSslEnabled: response.isSslEnabled,
+            isHealthy: response.isHealthy,
+            restVersion: response.restVersion,
+            wsUrl,
+        };
+    }
+
+    async getNodes(onlySSL = true, limit = 0, order = null): Promise<NodeApiNodeInfo[]> {
+        const params = `only_ssl=${onlySSL}&limit=${limit}${order ? `&order=${order}` : ''}`;
+
+        const [apiNodesResponse, peerNodesResponse] = await Promise.all([
+            this.get(`/api/symbol/nodes/api?${params}`),
+            this.get(`/api/symbol/nodes/peer?${params}`),
+        ]);
+
+        return [...apiNodesResponse, ...peerNodesResponse].map((node: any) => this.mapResponseToNodeApiInfo(node));
+    }
+
+    async getNodeByMainPublicKey(mainPublicKey: string): Promise<NodeApiNodeInfo | undefined> {
+        try {
+            const response = await this.get(`/api/symbol/nodes/mainPublicKey/${mainPublicKey}`);
+            return this.mapResponseToNodeApiInfo(response);
+        } catch (error) {
+            return undefined;
+        }
+    }
+
+    async getNodeByNodePublicKey(nodePublicKey: string): Promise<NodeApiNodeInfo | undefined> {
+        try {
+            const response = await this.get(`/api/symbol/nodes/nodePublicKey/${nodePublicKey}`);
+            return this.mapResponseToNodeApiInfo(response);
+        } catch (error) {
+            return undefined;
+        }
+    }
+
+    async get(route: string) {
+        const response = await fetch(`${this.url}${route}`, {});
+        if (!response.ok) {
+            throw new Error(`Node watch response was not ok: ${response.statusText}`);
+        }
+        return await response.json();
+    }
+}

--- a/src/services/NodeWatchService.ts
+++ b/src/services/NodeWatchService.ts
@@ -20,18 +20,15 @@ export class NodeWatchService {
     }
 
     private mapResponseToNodeApiInfo(response: any): NodeApiNodeInfo {
-        const endpoint = response.endpoint.replace('http', 'https').replace('3000', '3001');
-        const wsUrl = endpoint.replace('https', 'wss') + '/ws';
-
         return {
-            endpoint,
+            endpoint: response.endpoint,
             friendlyName: response.name,
             mainPublicKey: response.mainPublicKey,
             nodePublicKey: response.nodePublicKey,
             isSslEnabled: response.isSslEnabled,
             isHealthy: response.isHealthy,
             restVersion: response.restVersion,
-            wsUrl,
+            wsUrl: response.endpoint.replace('http', 'ws') + '/ws',
         };
     }
 

--- a/src/services/NodeWatchService.ts
+++ b/src/services/NodeWatchService.ts
@@ -25,7 +25,7 @@ export class NodeWatchService {
 
         return {
             endpoint,
-            friendlyName: response.friendlyName,
+            friendlyName: response.name,
             mainPublicKey: response.mainPublicKey,
             nodePublicKey: response.nodePublicKey,
             isSslEnabled: response.isSslEnabled,

--- a/src/store/Account.ts
+++ b/src/store/Account.ts
@@ -436,7 +436,7 @@ export default {
                 dispatch('harvesting/SET_CURRENT_SIGNER_HARVESTING_MODEL', currentSignerAddress.plain(), { root: true });
                 const networkType = rootGetters['network/networkType'];
                 const nodeService = new NodeService();
-                const nodes = await nodeService.getNodesFromStatisticService(networkType);
+                const nodes = await nodeService.getNodesFromNodeWatchService(networkType);
                 if (nodes && nodes.length && navigator.onLine) {
                     dispatch('harvesting/LOAD_HARVESTED_BLOCKS_STATS', {}, { root: true });
                 }

--- a/src/store/Harvesting.ts
+++ b/src/store/Harvesting.ts
@@ -208,11 +208,11 @@ export default {
             const nodeService = new NodeService();
             const networkType: NetworkType = rootGetters['network/networkType'];
             // try to find owned node with currentSignerAccountInfo.publicKey
-            let nodeInfo = await nodeService.getNodeFromStatisticServiceByPublicKey(networkType, currentSignerAccountInfo.publicKey);
+            let nodeInfo = await nodeService.getNodeFromNodeWatchServiceByMainPublicKey(networkType, currentSignerAccountInfo.publicKey);
 
             // try to find a linked node if it is not an owned node
             if (!nodeInfo && accountNodePublicKey) {
-                nodeInfo = await nodeService.getNodeFromStatisticServiceByNodePublicKey(networkType, accountNodePublicKey);
+                nodeInfo = await nodeService.getNodeFromNodeWatchServiceByNodePublicKey(networkType, accountNodePublicKey);
             }
             let unlockedAccounts: string[] = [];
 

--- a/src/store/Network.ts
+++ b/src/store/Network.ts
@@ -608,7 +608,7 @@ export default {
             const nodeService = new NodeService();
             const networkType = getters['networkType'];
             const isOffline = getters['isOfflineMode'];
-            commit('peerNodes', _.uniqBy(await nodeService.getNodesFromNodeWatchService(networkType, 100, false, isOffline), 'url'));
+            commit('peerNodes', _.uniqBy(await nodeService.getNodesFromNodeWatchService(networkType, 100, isOffline), 'url'));
         },
 
         // set current difference between server and local time

--- a/src/store/Network.ts
+++ b/src/store/Network.ts
@@ -311,8 +311,8 @@ export default {
                     progressTotalNumOfNodes: 1,
                 });
                 const nodeService = new NodeService();
-                const statisticsServiceNodes = !isOffline ? await nodeService.getNodesFromStatisticService(networkType) : undefined;
-                const nodesList = statisticsServiceNodes || nodeService.loadNodes(currentProfile);
+                const nodeWatchServiceNodes = !isOffline ? await nodeService.getNodesFromNodeWatchService(networkType) : undefined;
+                const nodesList = nodeWatchServiceNodes || nodeService.loadNodes(currentProfile);
 
                 const nodeWsUrl = nodesList.find((n) => n.url === newCandidateUrl)?.wsUrl;
                 nodeNetworkModelResult = await networkService
@@ -340,8 +340,9 @@ export default {
                 return;
             } else {
                 const nodeService = new NodeService();
-                const statisticsServiceNodes = !isOffline ? await nodeService.getNodesFromStatisticService(networkType) : undefined;
-                let nodesList = statisticsServiceNodes || nodeService.loadNodes(currentProfile);
+                const nodeWatchServiceNodes = !isOffline ? await nodeService.getNodesFromNodeWatchService(networkType) : undefined;
+
+                let nodesList = nodeWatchServiceNodes || nodeService.loadNodes(currentProfile);
                 let nodeFound = false,
                     progressCurrentNodeInx = 0;
                 const numOfNodes = nodesList.length;
@@ -607,7 +608,7 @@ export default {
             const nodeService = new NodeService();
             const networkType = getters['networkType'];
             const isOffline = getters['isOfflineMode'];
-            commit('peerNodes', _.uniqBy(await nodeService.getNodesFromStatisticService(networkType, 100, false, isOffline), 'url'));
+            commit('peerNodes', _.uniqBy(await nodeService.getNodesFromNodeWatchService(networkType, 100, false, isOffline), 'url'));
         },
 
         // set current difference between server and local time

--- a/src/views/forms/FormPersistentDelegationRequestTransaction/FormPersistentDelegationRequestTransactionTs.ts
+++ b/src/views/forms/FormPersistentDelegationRequestTransaction/FormPersistentDelegationRequestTransactionTs.ts
@@ -281,7 +281,7 @@ export class FormPersistentDelegationRequestTransactionTs extends FormTransactio
     }
 
     public async getNodeOperatorPublicKey() {
-        const nodeInfo = await new NodeService().getNodeFromStatisticServiceByPublicKey(
+        const nodeInfo = await new NodeService().getNodeFromNodeWatchServiceByMainPublicKey(
             this.networkType,
             this.currentSignerAccountInfo?.publicKey,
         );


### PR DESCRIPTION
Problem: The Statistic service is going to sunset, and it requires migration to the node watch service.
Solution: added nodewatch service