### PR TITLE
[wallet/desktop] fix: remove manually logic update to https

### DIFF
--- a/__tests__/services/NodeWatchService.spec.ts
+++ b/__tests__/services/NodeWatchService.spec.ts
@@ -6,7 +6,7 @@ describe('services/NodeWatchService', () => {
     (global as any).fetch = mockFetch;
 
     const createMockNodeResponse = () => ({
-        endpoint: 'http://example.com:3000',
+        endpoint: 'https://example.com:3001',
         name: 'Node1',
         mainPublicKey: 'mainKey1',
         nodePublicKey: 'nodeKey1',

--- a/src/services/NodeWatchService.ts
+++ b/src/services/NodeWatchService.ts
@@ -20,18 +20,15 @@ export class NodeWatchService {
     }
 
     private mapResponseToNodeApiInfo(response: any): NodeApiNodeInfo {
-        const endpoint = response.endpoint.replace('http', 'https').replace('3000', '3001');
-        const wsUrl = endpoint.replace('https', 'wss') + '/ws';
-
         return {
-            endpoint,
+            endpoint: response.endpoint,
             friendlyName: response.name,
             mainPublicKey: response.mainPublicKey,
             nodePublicKey: response.nodePublicKey,
             isSslEnabled: response.isSslEnabled,
             isHealthy: response.isHealthy,
             restVersion: response.restVersion,
-            wsUrl,
+            wsUrl: response.endpoint.replace('http', 'ws') + '/ws',
         };
     }
 


### PR DESCRIPTION
Problem: nodewatch will handle the endpoint for https if SSL is enabled.
Solution: Removed manually logic