### PR TITLE
[wallet/desktop] feat: upgrade symbol sdk v2.0.6

### DIFF
--- a/__tests__/components/TransactionList/TransactionList.spec.ts
+++ b/__tests__/components/TransactionList/TransactionList.spec.ts
@@ -307,7 +307,7 @@ describe('components/TransactionList', () => {
             vm.activePartialTransaction = createMockAggregateTransaction(null);
 
             // Act + Assert:
-            expect(vm.aggregateTransactionHash).toBe('A9683281822EED5D05FD99D3D9E2C12C8D8A8286012386BBFBDAEF5CE175977A');
+            expect(vm.aggregateTransactionHash).toBe('07F92EAA38A94011365B108E7DDDAE072360722458B359E79B63F52F88CE64AA');
         });
     });
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -28,7 +28,7 @@
                 "request": "^2.88.0",
                 "rss-parser": "^3.13.0",
                 "rxjs": "^6.6.7",
-                "symbol-sdk": "^2.0.4",
+                "symbol-sdk": "^2.0.6",
                 "trezor-connect": "^7.0.5",
                 "utf8": "^3.0.0",
                 "vee-validate": "^3.2.3",
@@ -35121,9 +35121,9 @@
             }
         },
         "node_modules/symbol-sdk": {
-            "version": "2.0.4",
-            "resolved": "https://registry.npmjs.org/symbol-sdk/-/symbol-sdk-2.0.4.tgz",
-            "integrity": "sha512-Z+54yxIld2WfboCpsIg3sZ4qtytfwA9cdXcADiZ3r7rFuEdAAEI5XT7cOqZhr52TOr5gtmzJOmzaeHeTBkm+gQ==",
+            "version": "2.0.6",
+            "resolved": "https://registry.npmjs.org/symbol-sdk/-/symbol-sdk-2.0.6.tgz",
+            "integrity": "sha512-Vx3yMTs3XnG0NJ3keqWuwni5b8kY4CEyOhLYS5VRWHMrO4xnANbrYXwgjF+jJqzWJkzkTwPiJAMaNaZUI88vZQ==",
             "dependencies": {
                 "@js-joda/core": "^3.2.0",
                 "catbuffer-typescript": "^1.0.2",
@@ -66804,9 +66804,9 @@
             }
         },
         "symbol-sdk": {
-            "version": "2.0.4",
-            "resolved": "https://registry.npmjs.org/symbol-sdk/-/symbol-sdk-2.0.4.tgz",
-            "integrity": "sha512-Z+54yxIld2WfboCpsIg3sZ4qtytfwA9cdXcADiZ3r7rFuEdAAEI5XT7cOqZhr52TOr5gtmzJOmzaeHeTBkm+gQ==",
+            "version": "2.0.6",
+            "resolved": "https://registry.npmjs.org/symbol-sdk/-/symbol-sdk-2.0.6.tgz",
+            "integrity": "sha512-Vx3yMTs3XnG0NJ3keqWuwni5b8kY4CEyOhLYS5VRWHMrO4xnANbrYXwgjF+jJqzWJkzkTwPiJAMaNaZUI88vZQ==",
             "requires": {
                 "@js-joda/core": "^3.2.0",
                 "catbuffer-typescript": "^1.0.2",

--- a/package.json
+++ b/package.json
@@ -62,7 +62,7 @@
         "request": "^2.88.0",
         "rss-parser": "^3.13.0",
         "rxjs": "^6.6.7",
-        "symbol-sdk": "^2.0.4",
+        "symbol-sdk": "^2.0.6",
         "trezor-connect": "^7.0.5",
         "utf8": "^3.0.0",
         "vee-validate": "^3.2.3",


### PR DESCRIPTION
Problem: Catapult-Server network compatibility issue (catapult-server@1.0.3.9) requires upgrading to symbol-sdk@2.0.6.
Solution: Upgrade to symbol-sdk@2.0.6